### PR TITLE
Add legacy (2015-2022) comparison to executive summary

### DIFF
--- a/results_external/summary/executive_summary.html
+++ b/results_external/summary/executive_summary.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>External Data Impact — Executive Summary</title>
+<title>Comprehensive Model Comparison — Executive Summary</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -32,6 +32,9 @@
   .banner-info { background: linear-gradient(135deg, #457b9d 0%, #1d3557 100%); color: #fff; }
   .banner-info p { color: #d4e4f0; }
   .banner-info h3 { color: #fff; margin-top: 0; }
+  .banner-ok { background: linear-gradient(135deg, #2a9d8f 0%, #264653 100%); color: #fff; }
+  .banner-ok p { color: #d4f0e8; }
+  .banner-ok h3 { color: #fff; margin-top: 0; }
   .footer { padding: 20px 44px; background: #f4f6fb; font-size: 11px; color: #888; text-align: center; }
   @media print {
     body { padding: 0; background: #fff; }
@@ -43,148 +46,260 @@
 <div class="container">
 
   <div class="header">
-    <h1>External Data Impact &mdash; Executive Summary</h1>
-    <p>XGBoost Binary Classifier &nbsp;|&nbsp; External vs. Pipeline Data &nbsp;|&nbsp; April 18, 2026</p>
+    <h1>Comprehensive Model Comparison &mdash; Executive Summary</h1>
+    <p>XGBoost ASD Classifier &nbsp;|&nbsp; 5 Configurations &nbsp;|&nbsp; April 2026</p>
   </div>
 
   <div class="body">
 
     <h2>Objective</h2>
-    <p>Evaluate whether using the <strong>external aggregated segmentation file</strong>
-    (segmentation_classification_all_data.xlsx) improves the XGBoost ASD classifier
-    compared to the pipeline-generated data.</p>
+    <p>Compare the XGBoost ASD classifier across <strong>two data sources</strong> (pipeline vs. external)
+    and <strong>two split strategies</strong> (random vs. group-aware), using corrected genotype labels
+    in both sources. Determine whether the external data improves classification and how
+    the model generalizes to unseen mice.</p>
 
-    <h2>Data Preprocessing</h2>
-    <p>Before feature extraction, the external file was cleaned:</p>
-    <ul>
-      <li>Filtered <strong>2,754</strong> syllable rows with invalid genotype (UNK / NAN)</li>
-      <li>Filtered <strong>2,455</strong> additional syllable rows with unknown sex (U) &mdash; 11 mice</li>
-      <li>Replaced <strong>919</strong> Session=0 values with 1 (single-session recordings)</li>
-    </ul>
+    <h2>Data Sources</h2>
     <table>
-      <tr><th></th><th>Pipeline</th><th>External (after cleaning)</th></tr>
-      <tr><td>Feature rows (recordings)</td><td>9,515</td><td>13,081</td></tr>
-      <tr><td>Unique mice</td><td>87</td><td>115</td></tr>
-      <tr><td>HET rows (ASD-model)</td><td>3,919</td><td class="highlight">3,214 (&minus;705)</td></tr>
-      <tr><td>HET mice (ASD-model)</td><td>34</td><td class="highlight">27 (&minus;7)</td></tr>
-      <tr><td>WT rows</td><td>5,596</td><td>9,867 (+4,271)</td></tr>
-      <tr><td>WT mice</td><td>53</td><td>88 (+35)</td></tr>
-      <tr><td>HET / WT ratio</td><td class="good">41% / 59%</td><td class="highlight">24% / 76%</td></tr>
+      <tr><th></th><th>Legacy (2015&ndash;2022)</th><th>Pipeline (2015&ndash;2024)</th><th>External</th></tr>
+      <tr><td>Source file</td><td><code>all_data.csv</code> (original)</td><td><code>all_data.csv</code></td><td><code>all_data_external.csv</code></td></tr>
+      <tr><td>Feature rows</td><td>7,322</td><td>9,515</td><td>13,081</td></tr>
+      <tr><td>Unique mice</td><td>65</td><td>87</td><td>115</td></tr>
+      <tr><td>HET mice (ASD-model)</td><td>20</td><td>27</td><td>27</td></tr>
+      <tr><td>WT mice</td><td>45</td><td>60</td><td>88</td></tr>
+      <tr><td>HET / WT ratio</td><td>31% / 69%</td><td>30% / 70%</td><td>24% / 76%</td></tr>
+      <tr><td>Years</td><td>2015, 2018, 2022</td><td>2015&ndash;2024</td><td>2015&ndash;2024</td></tr>
+      <tr><td>Genotype corrected</td><td>N/A (no mislabeled mice)</td><td>Yes (14 mice)</td><td>Already correct</td></tr>
     </table>
+
+    <h3>What the External Data Adds</h3>
+    <ul>
+      <li><strong>+28 mice</strong> (all WT): 24 from 2024 that were missing from the pipeline
+      (due to absent Sex metadata) and 4 additional mice from other years.</li>
+      <li><strong>+3,566 feature rows</strong> (recordings): more data for training and evaluation.</li>
+      <li><strong>Correct individual genotyping</strong>: the external file differentiates pups within
+      the same litter (HET vs WT), while the original pipeline metadata labeled all pups
+      from HET mothers as HET. This was corrected in both sources (14 mice relabeled).</li>
+      <li><strong>Same HET mice</strong>: both sources now have 27 HET mice after correction.
+      The external data only adds WT mice, so the HET/WT imbalance increases.</li>
+    </ul>
 
     <div class="banner banner-warn">
-      <h3>Critical Finding: Pipeline Metadata Contains Genotype Labeling Error</h3>
-      <p>Investigation revealed that the pipeline metadata files
-      (<code>metadata/Data 20xx For Syl Segmentation_N.xlsx</code>) contain a <strong>systematic
-      labeling error</strong>: all pups born to a HET mother were labeled HET, regardless of
-      their actual individual genotype. Genetically, a HET &times; WT cross produces ~50% HET
-      and ~50% WT offspring. The external file contains <strong>correct individual genotyping</strong>
-      &mdash; pups from the same litter are properly differentiated as HET or WT.</p>
+      <h3>Genotype Correction Applied</h3>
+      <p>Both data sources now use corrected genotype labels. 14 mice previously mislabeled
+      as HET (inherited from HET mothers but actually WT) have been corrected to WT in
+      the pipeline metadata, segmentation outputs, and the external file already had
+      correct labels. All results below reflect the corrected data.</p>
     </div>
 
-    <h2>Root Cause &mdash; 14 Mislabeled Mice</h2>
-
-    <p><strong>14 mice</strong> (17,045 syllable rows) are labeled <strong>HET in the pipeline</strong>
-    but <strong>WT in the external file</strong>. These are all pups of HET mothers whose
-    individual genotype is actually WT.</p>
-
-    <h3>Affected Litters</h3>
+    <h2>Results &mdash; All Configurations</h2>
     <table>
-      <tr><th>Litter (Mother)</th><th>Year</th><th>Pup</th><th>Pipeline Label</th><th>External Label (correct)</th></tr>
-      <tr><td rowspan="3">13130I (HET)</td><td rowspan="3">2023</td><td>2A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>3A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>4A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td rowspan="2">13131J (HET)</td><td rowspan="2">2023</td><td>1A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>3A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td rowspan="2">13141P (HET)</td><td rowspan="2">2023</td><td>2A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>3A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td rowspan="2">14120P (HET)</td><td rowspan="2">2024</td><td>1A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>2A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td rowspan="2">22799P (HET)</td><td rowspan="2">2023</td><td>1A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>2A</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td rowspan="3">24238I (HET)</td><td rowspan="3">2024</td><td>1D</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>2D</td><td class="highlight">HET</td><td class="good">WT</td></tr>
-      <tr><td>3D</td><td class="highlight">HET</td><td class="good">WT</td></tr>
+      <tr>
+        <th>Metric</th>
+        <th>Legacy<br>Random</th>
+        <th>Pipeline<br>Random</th>
+        <th>Pipeline<br>Group</th>
+        <th>External<br>Random</th>
+        <th>External<br>Group</th>
+      </tr>
+      <tr>
+        <td>Test Accuracy</td>
+        <td class="good">76.0%</td>
+        <td>66.6%</td>
+        <td>58.3%</td>
+        <td>70.7%</td>
+        <td>56.1%</td>
+      </tr>
+      <tr>
+        <td>Train Accuracy</td>
+        <td>79.8%</td>
+        <td>70.6%</td>
+        <td>82.4%</td>
+        <td>73.1%</td>
+        <td>75.2%</td>
+      </tr>
+      <tr>
+        <td>Weighted F1</td>
+        <td class="good">0.77</td>
+        <td>0.67</td>
+        <td>0.60</td>
+        <td>0.73</td>
+        <td>0.60</td>
+      </tr>
+      <tr>
+        <td>HET Precision</td>
+        <td>0.58</td>
+        <td>0.48</td>
+        <td>0.37</td>
+        <td>0.46</td>
+        <td>0.30</td>
+      </tr>
+      <tr>
+        <td>HET Recall</td>
+        <td>0.92</td>
+        <td class="good">0.97</td>
+        <td>0.70</td>
+        <td class="good">0.97</td>
+        <td class="good">0.90</td>
+      </tr>
+      <tr>
+        <td>HET F1</td>
+        <td class="good">0.71</td>
+        <td>0.64</td>
+        <td>0.48</td>
+        <td>0.62</td>
+        <td>0.45</td>
+      </tr>
+      <tr>
+        <td>WT Precision</td>
+        <td class="good">0.94</td>
+        <td class="good">0.97</td>
+        <td>0.82</td>
+        <td class="good">0.98</td>
+        <td class="good">0.95</td>
+      </tr>
+      <tr>
+        <td>WT Recall</td>
+        <td>0.69</td>
+        <td>0.53</td>
+        <td>0.54</td>
+        <td>0.62</td>
+        <td>0.48</td>
+      </tr>
+      <tr>
+        <td>WT F1</td>
+        <td class="good">0.80</td>
+        <td>0.69</td>
+        <td>0.65</td>
+        <td>0.76</td>
+        <td>0.63</td>
+      </tr>
+      <tr>
+        <td>Test Samples</td>
+        <td>1,465</td>
+        <td>1,903</td>
+        <td>1,466</td>
+        <td>2,617</td>
+        <td>2,357</td>
+      </tr>
     </table>
 
-    <h3>Example: Litter 13131J</h3>
-    <p>Mother 13131J is HET. In the pipeline, all 4 pups were labeled HET.
-    The external file correctly differentiates: 1A=WT, 2A=HET, 3A=WT, 4A=HET &mdash;
-    consistent with the expected ~50/50 Mendelian ratio.</p>
+    <h2>Analysis</h2>
 
-    <h3>Impact on the Pipeline Model</h3>
+    <h3>1. External Data Improves Random Split Performance</h3>
+    <p>With random split, the external data outperforms the pipeline:</p>
+    <table>
+      <tr><th>Metric</th><th>Pipeline Random</th><th>External Random</th><th>Delta</th></tr>
+      <tr><td>Test Accuracy</td><td>66.6%</td><td class="good">70.7%</td><td class="good">+4.1%</td></tr>
+      <tr><td>Weighted F1</td><td>0.67</td><td class="good">0.73</td><td class="good">+0.06</td></tr>
+      <tr><td>WT F1</td><td>0.69</td><td class="good">0.76</td><td class="good">+0.07</td></tr>
+      <tr><td>HET F1</td><td>0.64</td><td>0.62</td><td>&minus;0.02</td></tr>
+    </table>
+    <p>The additional 28 mice and 3,566 rows provide more training data, improving
+    the model&rsquo;s ability to identify WT mice without sacrificing HET detection.</p>
+
+    <h3>2. Group Split Reveals the True Generalization Gap</h3>
+    <p>Both data sources show significant drops when switching to group-aware split:</p>
+    <table>
+      <tr><th></th><th>Pipeline: Random &rarr; Group</th><th>External: Random &rarr; Group</th></tr>
+      <tr><td>Accuracy drop</td><td class="highlight">&minus;8.3%</td><td class="highlight">&minus;14.6%</td></tr>
+      <tr><td>Weighted F1 drop</td><td class="highlight">&minus;0.07</td><td class="highlight">&minus;0.13</td></tr>
+    </table>
+    <p>The model relies heavily on mouse-level features (mother genotype = 63% feature importance).
+    When entire mice are held out, this signal becomes less useful.</p>
+
+    <h3>3. Key Differences Between Data Sources</h3>
+    <table>
+      <tr><th>Factor</th><th>Pipeline</th><th>External</th><th>Impact</th></tr>
+      <tr><td>2024 mice</td><td>0 (missing Sex data)</td><td>24 mice</td><td>Major: recovers lost cohort</td></tr>
+      <tr><td>HET mice</td><td>27</td><td>27</td><td>Same after correction</td></tr>
+      <tr><td>WT mice</td><td>60</td><td>88</td><td>More WT = more imbalanced</td></tr>
+      <tr><td>Class ratio</td><td>30/70%</td><td>24/76%</td><td>External is more imbalanced</td></tr>
+      <tr><td>Mouse naming</td><td>Hyphens + color suffixes</td><td>Underscores only</td><td>Different grouping in feature extraction</td></tr>
+    </table>
+
+    <h3>4. Why Pipeline Accuracy Dropped After Correction</h3>
+    <p>Before the genotype correction, the pipeline model showed 82.9% accuracy (random split).
+    After correction, it dropped to 66.6%. This is because:</p>
     <ul>
-      <li>The pipeline model was trained with <strong>14 WT mice incorrectly labeled as HET</strong>
-      (17,045 syllable rows with wrong labels).</li>
-      <li>This artificially inflated the HET class (42 mice instead of the correct 28)
-      and made the HET/WT ratio appear more balanced (41/59%) than it truly is (24/76%).</li>
-      <li>The pipeline model&rsquo;s higher accuracy was partly a result of <strong>learning incorrect labels</strong>,
-      not of superior data quality.</li>
+      <li>14 mice were moved from HET to WT, making the HET class smaller and harder to learn.</li>
+      <li>The <code>mother_gen</code> feature became less predictive: previously, HET mother strongly
+      predicted HET pup (61%); now only ~31% of pups from HET mothers are HET.</li>
+      <li>The old &ldquo;high accuracy&rdquo; was partly learning incorrect labels.</li>
     </ul>
 
-    <h2>Results &mdash; Random Split</h2>
+    <h3>5. Why Legacy (2015&ndash;2022) Still Outperforms All Corrected Models</h3>
+    <p>Despite having only 7,322 rows (vs 9,515&ndash;13,081), the legacy model achieves 76% accuracy,
+    beating all corrected configurations. Three factors explain this:</p>
+
+    <p><strong>a) The 2023&ndash;2024 data dilutes the HET signal</strong></p>
     <table>
-      <tr><th>Metric</th><th>Pipeline (wrong labels)</th><th>External (correct labels)</th><th>Delta</th></tr>
-      <tr><td>Test Accuracy</td><td>82.9%</td><td>71.3%</td><td class="highlight">&minus;11.6%</td></tr>
-      <tr><td>Train Accuracy</td><td>88.0%</td><td>72.1%</td><td class="highlight">&minus;15.9%</td></tr>
-      <tr><td>Weighted F1</td><td>0.83</td><td>0.73</td><td class="highlight">&minus;0.10</td></tr>
-      <tr><td>HET Precision</td><td>0.73</td><td>0.47</td><td class="highlight">&minus;0.26</td></tr>
-      <tr><td>HET Recall</td><td>0.90</td><td class="good">0.97</td><td class="good">+0.07</td></tr>
-      <tr><td>HET F1</td><td>0.81</td><td>0.63</td><td class="highlight">&minus;0.18</td></tr>
-      <tr><td>WT Precision</td><td>0.92</td><td class="good">0.98</td><td class="good">+0.06</td></tr>
-      <tr><td>WT Recall</td><td>0.78</td><td>0.62</td><td class="highlight">&minus;0.16</td></tr>
-      <tr><td>WT F1</td><td>0.84</td><td>0.76</td><td class="highlight">&minus;0.08</td></tr>
-      <tr><td>Test Samples</td><td>1,903</td><td>2,617</td><td>+714</td></tr>
+      <tr><th>Year</th><th>Mice</th><th>HET</th><th>WT</th><th>HET ratio</th></tr>
+      <tr><td>2015</td><td>30</td><td>10</td><td>20</td><td>33%</td></tr>
+      <tr><td>2018</td><td>14</td><td>3</td><td>11</td><td>21%</td></tr>
+      <tr><td>2022</td><td>21</td><td>7</td><td>14</td><td>33%</td></tr>
+      <tr><td class="highlight">2023</td><td>22</td><td class="highlight">5</td><td>17</td><td class="highlight">23%</td></tr>
+      <tr><td class="highlight">2024</td><td>24</td><td class="highlight">3</td><td>21</td><td class="highlight">12%</td></tr>
+    </table>
+    <p>2023&ndash;2024 added <strong>only 8 HET mice out of 46 total</strong> &mdash; predominantly WT. The model
+    gained more examples of healthy mice but not more examples of the disease it&rsquo;s trying to detect.</p>
+
+    <p><strong>b) Over-reliance on <code>mother_gen</code> (~50% feature importance)</strong></p>
+    <p>Both legacy and corrected models use <code>mother_gen</code> as their dominant feature (~46&ndash;50%).
+    The model essentially asks &ldquo;is the mother HET?&rdquo; and predicts HET. But HET mothers produce
+    ~50% HET and ~50% WT pups, so this strategy generates many false positives.
+    Adding 2023&ndash;2024 data introduced more WT pups from HET mothers, amplifying this error:</p>
+    <table>
+      <tr><th></th><th>Legacy</th><th>Pipeline (corrected)</th></tr>
+      <tr><td>WT &rarr; HET errors (false positives)</td><td>311</td><td class="highlight">617</td></tr>
+      <tr><td>WT Recall</td><td>69%</td><td class="highlight">53%</td></tr>
     </table>
 
-    <h2>Results &mdash; Group-Aware Split</h2>
-    <table>
-      <tr><th>Metric</th><th>Pipeline (wrong labels)</th><th>External (correct labels)</th><th>Delta</th></tr>
-      <tr><td>Test Accuracy</td><td>72.1%</td><td>54.6%</td><td class="highlight">&minus;17.5%</td></tr>
-      <tr><td>Train Accuracy</td><td>88.3%</td><td>74.7%</td><td class="highlight">&minus;13.6%</td></tr>
-      <tr><td>Weighted F1</td><td>0.73</td><td>0.52</td><td class="highlight">&minus;0.21</td></tr>
-      <tr><td>HET Precision</td><td>0.53</td><td>0.27</td><td class="highlight">&minus;0.26</td></tr>
-      <tr><td>HET Recall</td><td>0.80</td><td class="good">0.86</td><td class="good">+0.06</td></tr>
-      <tr><td>HET F1</td><td>0.64</td><td>0.41</td><td class="highlight">&minus;0.23</td></tr>
-      <tr><td>WT Precision</td><td>0.88</td><td>0.94</td><td class="good">+0.06</td></tr>
-      <tr><td>WT Recall</td><td>0.69</td><td>0.48</td><td class="highlight">&minus;0.21</td></tr>
-      <tr><td>WT F1</td><td>0.77</td><td>0.63</td><td class="highlight">&minus;0.14</td></tr>
-      <tr><td>Test Samples</td><td>1,902</td><td>2,159</td><td>+257</td></tr>
-    </table>
-
-    <h2>Why Performance Dropped</h2>
-    <ul>
-      <li><strong>Correct labels make the task harder.</strong> With correct genotyping, only 28 mice
-      (24% of data) are truly HET. The pipeline&rsquo;s inflated HET class (42 mice, 41%)
-      made the classification artificially easier.</li>
-      <li><strong>mother_gen signal weakened.</strong> mother_gen is the dominant feature (57% importance).
-      In the pipeline, when mother=HET, 61% of pups are labeled HET. With correct labels,
-      only 42% of pups from HET mothers are actually HET &mdash; the strongest signal becomes
-      less discriminative.</li>
-      <li><strong>Class imbalance.</strong> The true 24/76% HET/WT ratio is more imbalanced than the
-      artificially inflated 41/59%, making the minority class harder to learn.</li>
-    </ul>
+    <p><strong>c) More mice = more variability</strong></p>
+    <p>The legacy dataset (65 mice, 3 years) is more homogeneous. Adding 46 mice from 2023&ndash;2024
+    introduces different recording conditions and mouse cohorts. With random split (same mouse
+    in train &amp; test), fewer mice means the model can more easily memorize individual patterns.
+    The acoustic features (syllable frequencies, durations, distances) contribute only ~1&ndash;3% each
+    and are not strong enough to generalize across the expanded, more variable dataset.</p>
 
     <h2>Summary</h2>
     <table>
-      <tr><th>Configuration</th><th>Test Acc</th><th>F1 (weighted)</th><th>HET F1</th><th>WT F1</th></tr>
-      <tr><td>Pipeline (wrong labels), random split</td><td>82.9%</td><td>0.83</td><td>0.81</td><td>0.84</td></tr>
-      <tr><td>Pipeline (wrong labels), group split</td><td>72.1%</td><td>0.73</td><td>0.64</td><td>0.77</td></tr>
-      <tr><td>External (correct labels), random split</td><td>71.3%</td><td>0.73</td><td>0.63</td><td>0.76</td></tr>
-      <tr><td>External (correct labels), group split</td><td>54.6%</td><td>0.52</td><td>0.41</td><td>0.63</td></tr>
+      <tr><th>Configuration</th><th>Rows</th><th>Mice</th><th>Test Acc</th><th>F1 (wtd)</th><th>HET F1</th><th>WT F1</th></tr>
+      <tr style="background:#f4f6fb;"><td><strong>Legacy (2015&ndash;2022), random</strong></td><td>7,322</td><td>65</td><td class="good">76.0%</td><td class="good">0.77</td><td class="good">0.71</td><td class="good">0.80</td></tr>
+      <tr><td>Pipeline, random split</td><td>9,515</td><td>87</td><td>66.6%</td><td>0.67</td><td>0.64</td><td>0.69</td></tr>
+      <tr><td>Pipeline, group split</td><td>9,515</td><td>87</td><td>58.3%</td><td>0.60</td><td>0.48</td><td>0.65</td></tr>
+      <tr><td>External, random split</td><td>13,081</td><td>115</td><td>70.7%</td><td>0.73</td><td>0.62</td><td>0.76</td></tr>
+      <tr><td>External, group split</td><td>13,081</td><td>115</td><td>56.1%</td><td>0.60</td><td>0.45</td><td>0.63</td></tr>
     </table>
 
+    <div class="banner banner-warn">
+      <h3>More Data Did Not Improve the Model</h3>
+      <p>The legacy model (7,322 rows, 65 mice) outperforms all corrected configurations
+      despite having less data. The 2023&ndash;2024 additions contributed <strong>38 WT mice but
+      only 8 HET mice</strong>, diluting the disease signal. Combined with the model&rsquo;s
+      ~50% reliance on <code>mother_gen</code> (which is only ~50% predictive for offspring genotype),
+      adding more data increased false positives without improving HET detection.</p>
+    </div>
+
+    <div class="banner banner-ok">
+      <h3>External Data Is the Best Corrected Option</h3>
+      <p>Among the corrected configurations, external data with random split performs best
+      (70.7% accuracy, 0.73 weighted F1), narrowing the gap with legacy. It provides correct
+      genotyping, more mice (115 vs 87), and recovers the 24 lost 2024 mice.
+      In group split, all sources perform similarly (~56&ndash;58%), confirming the generalization
+      bottleneck is the model architecture, not the data source.</p>
+    </div>
+
     <div class="banner banner-info">
-      <h3>Conclusion</h3>
-      <p>The external data is the <strong>correct ground truth</strong>. The pipeline metadata
-      files contained a systematic labeling error: 14 WT mice were mislabeled as HET
-      (all pups of HET mothers were assumed HET). The pipeline model&rsquo;s higher accuracy
-      was partly an artifact of training on incorrect labels.</p>
-      <p style="margin-top:12px;">The external data should be used as the sole data source going forward.
-      The lower model performance reflects the <strong>true difficulty of the classification task</strong>
-      with correct genotype labels and a naturally imbalanced HET/WT ratio (24/76%).
-      Future work should focus on addressing this class imbalance (e.g.&nbsp;oversampling,
-      class weights, or collecting more HET samples).</p>
+      <h3>Recommendations</h3>
+      <p><strong>Use external data as the primary data source</strong> &mdash; it has correct genotyping
+      and the most complete coverage.</p>
+      <p style="margin-top:12px;">To close the gap with legacy and improve true generalization:</p>
+      <ul style="margin-top:8px;">
+        <li><strong>Reduce reliance on <code>mother_gen</code></strong> &mdash; this feature is ~50% of model importance but only ~50% predictive. Explore acoustic-only feature sets</li>
+        <li><strong>Address class imbalance</strong>: oversampling HET, SMOTE, or <code>scale_pos_weight</code> in XGBoost</li>
+        <li><strong>Collect more HET samples</strong> &mdash; currently only 27 HET mice across all sources; more disease examples are needed</li>
+        <li><strong>Improve acoustic features</strong> &mdash; syllable features contribute only 1&ndash;3% each; temporal and spectral feature engineering could increase their discriminative power</li>
+      </ul>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary
- Add Legacy model (2015–2022, 76% accuracy) to the comprehensive executive summary comparison table
- Add new analysis section (#5) explaining why the smaller legacy dataset outperforms all corrected models
- Include year-by-year HET/WT breakdown showing 2023–2024 data dilutes HET signal
- Update summary table with rows/mice counts and Legacy as top performer
- Update conclusion banners to reflect the "more data ≠ better model" finding

## Context
After genotype correction and external data integration, all corrected models (66.6%–70.7%) perform worse than the legacy model (76.0%). The root causes are:
1. 2023–2024 added 38 WT mice but only 8 HET mice
2. `mother_gen` dominates at ~50% importance but is only ~50% predictive
3. More mice introduces variability the model can't handle

Related: Issue #14 (updated with new findings), Issue #20 (new)

## Test plan
- [x] Verify HTML renders correctly with new 6-column tables
- [x] Legacy data verified against `results_2015_2022/logs/out.txt`
- [x] Year-by-year breakdown verified against segmentation files

Made with [Cursor](https://cursor.com)