### PR TITLE
Mark external dataset as the preferred data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All source code lives here:
   - `tests/` — smoke tests
 
 - **`src/classification/`** — ASD classification
-  - `train_classifier.py` — reads `outputs/aggregated/all_data.csv`, trains a classifier, and generates evaluation plots (confusion matrix, classification report). Supports multiple models via `--model` (default: XGBoost, also TabPFN), `--external` for external data, and `--group-split` for group-aware splitting. See `src/classification/TRAINING.md` for details.
+  - `train_classifier.py` — reads `outputs/aggregated/all_data.csv`, trains a classifier, and generates evaluation plots (confusion matrix, classification report). Supports multiple models via `--model` (default: XGBoost, also TabPFN), `--external` for the **preferred** externally-validated dataset, and `--group-split` for group-aware splitting. **Always use `--external` — it contains correct individual genotyping.** See `src/classification/TRAINING.md` for details.
   - `models.py` — model registry with factory functions for each supported classifier
   - `report.py` — generates comparison-vs-baseline summary
 
@@ -202,8 +202,8 @@ The `generate_metadata.py` script supports scanning WAV files directly from Goog
 7. **Aggregation**  
    Combines all per-file outputs into `outputs/aggregated/all_data.xlsx` and `outputs/aggregated/all_data.csv` (overwrites if they already exist).
 
-8. **External Data Aggregation**  
-   Alternatively, aggregates features from the external segmentation file (`outputs/external/segmentation_classification_all_data.xlsx`) into `outputs/aggregated_external/`. This file contains correct individual genotyping and is the recommended data source. Cleaning steps: filters invalid genotype labels (UNK/NAN), unknown sex (U), and normalizes Session=0 to 1.
+8. **External Data Aggregation (Preferred)**  
+   Aggregates features from the external segmentation file (`outputs/external/segmentation_classification_all_data.xlsx`) into `outputs/aggregated_external/`. **This is the preferred data source for all training runs** — it contains correct individual genotyping, unlike the pipeline-aggregated data which had genotype labeling errors. Cleaning steps: filters invalid genotype labels (UNK/NAN), unknown sex (U), and normalizes Session=0 to 1.
 
 ### Model Training
 
@@ -219,8 +219,11 @@ All flags compose independently for isolated, reproducible results:
 ```bash
 cd src/classification
 
-# Default XGBoost
-python train_classifier.py
+# Recommended: XGBoost with external data (preferred dataset)
+python train_classifier.py --external
+
+# XGBoost with external data + group-aware split (most rigorous)
+python train_classifier.py --external --group-split
 
 # TabPFN with group-aware split and external data
 python train_classifier.py --model tabpfn --group-split --external
@@ -240,9 +243,9 @@ See `src/classification/TRAINING.md` for full documentation on flags, results di
 - ✅ **Preprocessing pipeline** (`src/preprocessing/run_pipeline.py`) — segmentation, basic features, CNN classification, column enrichment, and feature extraction. Automatically normalizes folder structure on startup.
 - ✅ **ASD classification** (`src/classification/train_classifier.py`) — multi-model sick/healthy classifier (XGBoost, TabPFN)
 - ✅ **Supported data:** 2015, 2018, 2022, 2023, 2024
-- ✅ **External data integration** — `outputs/external/segmentation_classification_all_data.xlsx` with correct individual genotyping (recommended data source)
+- ✅ **External data integration (preferred)** — `outputs/external/segmentation_classification_all_data.xlsx` with correct individual genotyping. **This is the preferred data source; always train with `--external`.**
 - ⚠️ The available data is partial. Full dataset access requires access to the BGU lab servers.
-- ⚠️ **Genotype labeling:** The pipeline metadata files originally labeled all pups of HET mothers as HET. This was corrected in April 2026 — 14 mice were relabeled to WT based on individual genotyping. The external file is the ground truth for genotype labels.
+- ⚠️ **Genotype labeling:** The pipeline metadata files originally labeled all pups of HET mothers as HET. This was corrected in April 2026 — 14 mice were relabeled to WT based on individual genotyping. **The external file (`--external`) is the ground truth for genotype labels and should always be used.**
 
 ---
 

--- a/results/summary/executive_summary.html
+++ b/results/summary/executive_summary.html
@@ -79,9 +79,11 @@
         <td><code>results/xgboost_base/</code></td>
       </tr>
       <tr>
-        <td>External</td>
-        <td>Adds external USV data alongside pipeline data, increasing the dataset
-            to <strong>13,081 samples</strong>. More data generally improves generalization.</td>
+        <td><strong>External (Preferred)</strong></td>
+        <td><strong>Recommended for all runs.</strong> Uses the externally-validated dataset with
+            correct individual genotyping (<strong>13,081 samples</strong>). The pipeline-aggregated
+            data had genotype labeling errors (all pups of HET mothers were labeled HET);
+            the external file is the ground truth.</td>
         <td><code>--external</code></td>
         <td><code>results/xgboost_external/</code></td>
       </tr>
@@ -102,6 +104,14 @@
         <td><code>results/xgboost_group_split_external/</code></td>
       </tr>
     </table>
+
+    <div class="banner banner-ok">
+      <h3>External Data Is the Preferred Dataset</h3>
+      <p>The <code>--external</code> flag uses the externally-validated dataset with correct
+      individual genotyping. The pipeline-aggregated data (<code>all_data.csv</code>) had
+      genotype labeling errors &mdash; all pups of HET mothers were labeled HET, when ~50%
+      are actually WT. <strong>Always use <code>--external</code> for training runs.</strong></p>
+    </div>
 
     <div class="legend">
       <strong>Directory naming convention:</strong>

--- a/src/classification/TRAINING.md
+++ b/src/classification/TRAINING.md
@@ -23,6 +23,15 @@ segmentation_*.xlsx          (per-file, all syllable rows + enrichment columns)
 > Enrichment columns (Complexity level, Syllable type, Noise, etc.) exist
 > only in the `.xlsx` files and **never reach the model**.
 
+## Preferred Data Source
+
+> **The external dataset (`--external` flag / `all_data_external.csv`) is the
+> preferred data source for all training runs.** It contains correct individual
+> genotyping data, unlike the pipeline-aggregated `all_data.csv` which had
+> genotype labeling errors (all pups of HET mothers were labeled HET, when in
+> reality ~50% are WT). Always use `--external` unless you have a specific
+> reason not to.
+
 ## Input: `all_data.csv`
 
 Each row = **one recording** of one mouse. 48 columns total:
@@ -109,7 +118,7 @@ python train_classifier.py [--model MODEL] [--group-split] [--external] [--resul
 |-----------------|--------------------------------------------------------------|
 | `--model`       | Model to train: `xgboost` (default), `tabpfn`               |
 | `--group-split` | Group-aware split by mouse identity (prevents data leakage)  |
-| `--external`    | Use external aggregated data (`all_data_external.csv`)       |
+| `--external`    | **Recommended.** Use the externally-validated dataset with correct individual genotyping (`all_data_external.csv`). This is the preferred data source. |
 | `--results-dir` | Override default results directory                           |
 
 ### Results directory naming

--- a/src/classification/train_classifier.py
+++ b/src/classification/train_classifier.py
@@ -62,7 +62,8 @@ def parse_args():
     parser.add_argument(
         '--external',
         action='store_true',
-        help='Use external aggregated data (all_data_external.csv) instead of the default.',
+        help='RECOMMENDED. Use the externally-validated dataset with correct individual '
+             'genotyping (all_data_external.csv). This is the preferred data source.',
     )
     parser.add_argument(
         '--results-dir',

--- a/src/preprocessing/steps/extract_features.py
+++ b/src/preprocessing/steps/extract_features.py
@@ -209,7 +209,12 @@ def run_external_aggregated_feature_extraction(
     output_dir: str = "",
     logger: Optional[logging.Logger] = None,
 ) -> str:
-    """Run feature extraction on a single external Excel file containing all segmentation data.
+    """Run feature extraction on the external segmentation file (preferred dataset).
+
+    This produces the **preferred** training data. The external file contains
+    correct individual genotyping, unlike the pipeline-aggregated data which
+    had genotype labeling errors. Always use this output (``--external``) for
+    training unless you have a specific reason not to.
 
     Same pipeline as ``run_aggregated_feature_extraction`` but reads one
     pre-concatenated workbook instead of globbing individual per-file


### PR DESCRIPTION
## Summary

- Updated all documentation, CLI help text, and code docstrings to clearly mark the external dataset (`--external` flag) as the **preferred data source** for all training runs.
- The external dataset contains correct individual genotyping, unlike the pipeline-aggregated data which had genotype labeling errors (all pups of HET mothers were labeled HET when ~50% are WT).
- Files updated: `train_classifier.py`, `TRAINING.md`, `README.md`, `executive_summary.html`, `extract_features.py`.

## Test plan

- [ ] Verify `python train_classifier.py --help` shows the updated `--external` description
- [ ] Review each updated doc for clarity and consistency

Made with [Cursor](https://cursor.com)