### PR TITLE
docs: README for threshold/ and threshold_objectives/ result folders

### DIFF
--- a/results/tabular_models/threshold/README.md
+++ b/results/tabular_models/threshold/README.md
@@ -1,0 +1,34 @@
+# `threshold/` — adopted decision-threshold runs (Youden)
+
+## Why this exists
+Issues #29 / #51. At the hard-coded **0.5** cut the tabular models sit at a poor
+operating point (very high HT recall but low HT precision / WT recall on
+dependent splits; HT *under*-detection on independent splits). The predicted
+probabilities separate the classes — 0.5 just doesn't exploit it. These runs
+derive a decision threshold from the **validation** set (leak-free) and apply it
+to **test**, reporting metrics at both **0.5** and the **tuned** threshold.
+
+Objective here is **Youden's J** (max TPR−FPR), the headline choice in #29. For a
+comparison of all objectives see [`../threshold_objectives/`](../threshold_objectives/).
+
+## What's in here
+- `summary_matrix.txt` — one-glance table of all 6 runs, 0.5 vs tuned.
+- One folder per run (6 primary runs: xgboost / xgboost_tuned / tabpfn ×
+  dependent / independent), each containing:
+  - `threshold_report.txt` — 0.5-vs-tuned side-by-side + confusion matrices.
+  - `threshold_metrics.json` — machine-readable metrics for both thresholds.
+  - `probabilities_val.csv` / `probabilities_test.csv` — per-sample P(HT) (the
+    val file is the leak-free source the threshold is derived from).
+  - `plots/roc_curve.png` (val ROC + operating points), `conf_matrix_thr0.5.png`,
+    `conf_matrix_thr_tuned.png`.
+
+TabPFN model pickles (~225 MB) are gitignored; everything else is committed.
+
+## How to regenerate
+```bash
+python scripts/run_threshold_matrix.py                  # all 6 runs, Youden
+python scripts/run_threshold_matrix.py --objective f1   # any other objective
+```
+TabPFN runs need `TABPFN_TOKEN` in `.env`. Splits are reproducible (`seed=100`).
+In threshold mode TabPFN keeps its validation split held out (no merge into
+train) so the threshold is derived leak-free.

--- a/results/tabular_models/threshold_objectives/README.md
+++ b/results/tabular_models/threshold_objectives/README.md
@@ -1,0 +1,42 @@
+# `threshold_objectives/` — objective comparison
+
+## Why this exists
+Follow-up to [`../threshold/`](../threshold/). Youden is a fine default, but on
+this data it isn't always the best operating point — on subject-dependent splits
+it over-pushes HT recall and hurts accuracy. This folder compares **all four
+objectives** (`youden` / `f1` / `target_recall` / `balanced`) plus the `0.5`
+default across the 6 runs, so we can pick the right cut per scenario.
+
+## No retraining
+The objective only changes which threshold is selected from the (objective-
+independent) validation probabilities — the trained model and its probabilities
+are identical for every objective. So this reads the per-sample probabilities
+already saved under `../threshold/<run>/probabilities_{val,test}.csv` and just
+re-derives + re-evaluates each objective. A self-check confirms the recomputed
+Youden numbers match the stored full-run metrics exactly (delta 0.0) for all 6
+runs. This avoids ~4h of TabPFN CPU inference.
+
+## What's in here
+- `summary_objectives.txt` — master table: 6 runs × {0.5, youden, f1,
+  target_recall, balanced}, on test.
+- `summary_objectives.csv` — same data for Excel / analysis.
+- One folder per run, each containing:
+  - `objective_comparison.txt` — per-run table + confusion matrices per objective.
+  - `objective_metrics.json` — machine-readable, all objectives.
+
+## Key finding
+- **Subject-dependent splits:** `f1` (or `target_recall`) give the best accuracy
+  and a balanced operating point (e.g. tabpfn dep acc 0.78 → 0.82). Youden
+  over-pushes recall.
+- **Subject-independent splits:** weak AUC (~0.75–0.78); youden/f1/balanced
+  collapse to a near-degenerate "predict HT for almost everyone" point (HT recall
+  ~1.0, WT recall ~0.59). `target_recall` keeps a controlled operating point.
+
+Recommendation: adopt `f1` for dependent runs, `target_recall` (≈0.80) for
+independent runs. Full writeup in issue #73.
+
+## How to regenerate
+```bash
+python scripts/compare_threshold_objectives.py                  # instant, from saved probabilities
+python scripts/compare_threshold_objectives.py --target-recall 0.85
+```


### PR DESCRIPTION
Adds a short `README.md` to each result folder summarising what it contains, what motivated it, the key finding, and how to regenerate. GitHub renders these on folder open.

- `results/tabular_models/threshold/README.md` — adopted Youden runs.
- `results/tabular_models/threshold_objectives/README.md` — objective comparison.

Refs #29, #51, #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)