### PR TITLE
docs(results): uniform per-run README summaries across results/

### DIFF
--- a/results/legacy/neural_networks/bilstm_subject_eval_dependent/README.md
+++ b/results/legacy/neural_networks/bilstm_subject_eval_dependent/README.md
@@ -1,0 +1,62 @@
+# bilstm_subject_eval_dependent — BiLSTM · subject-dependent
+
+**Status:** archived — superseded by `results/neural_networks/bilstm_subject_eval_dependent_baseline`.
+
+> BiLSTM over per-syllable USV sequences, dependent (leaky) split — **collapses to predicting WT for every session**.
+
+## Overview
+- **Model:** BiLSTM (~149K params) over chronological per-syllable sequences (order preserved,
+  `MAX_SEQ_LEN=256`), not the 48 aggregated per-recording tabular features. Scored at **session level**.
+- **Evaluation split:** subject-dependent — random session-level split (`group_split=false`), so the same
+  mouse can land in both train and test (train/val: 57, train/test: 61 shared mice per the log → leaky,
+  optimistic).
+- **Dataset:** external/all-data CSV cache — 442 sessions from 119 mice (WT 336 / HT 106 ≈ 24% HT);
+  split into 264 train / 89 val / 89 test sessions, each ~76% WT / 24% HT.
+- **Levers:** control run (defaults, "none (baseline)"). Class weighting `pos_weight=0.320`,
+  Adam LR 1e-3 with decay, early stopping at epoch 16 (best val AUC 0.828).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.764 | 0.000 | — |
+| Recall | 1.000 | 0.000 | — |
+| F1 | 0.866 | 0.000 | weighted **0.662** |
+| Accuracy | | | **0.764** (train 0.758) |
+
+Test AUC 0.742 · best val AUC 0.828. The "accuracy" 0.764 is exactly the WT share of the 89 test
+sessions (68/89) — the model assigns WT to **every** session, so HT recall = 0.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.764 | 0.733 | +0.031 |
+| Weighted F1 | 0.662 | 0.749 | −0.087 |
+| WT F1 | 0.866 | 0.785 | +0.081 |
+| HT F1 | 0.000 | 0.649 | −0.649 |
+| HT recall | 0.000 | 0.940 | −0.940 |
+| HT precision | 0.000 | 0.496 | −0.496 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 89 session-level sequences, whereas
+the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse:** the model predicts WT (the majority class) for all 89 test sessions — WT recall
+  1.000 / HT recall 0.000, HT F1 0.000. The headline "accuracy" 0.764 is just the test WT base rate, not
+  real skill.
+- The Δ table is dominated by this collapse: every HT metric drops to 0 (HT F1 −0.649, HT recall −0.940,
+  HT precision −0.496), and the only "gains" — WT F1 +0.081 and accuracy +0.031 — come trivially from
+  always predicting the majority class. The base model, by contrast, actually detects HT (recall 0.940).
+- Training did learn signal early (val AUC peaked 0.828 at epoch 1) but then **degraded every epoch**
+  (val AUC → 0.597, val loss rising) while train loss fell — overfitting to the leaky split before
+  early stopping fired. Test AUC 0.742 confirms weak separation despite the collapsed hard predictions.
+- Label mapping: `logs/out.txt` and `results.json` agree — support 68 (key `1.0`, "WT (1)") = WT and
+  support 21 (key `0.0`, "HT (0)") = HT, matching the ~76% WT / 24% HT test balance — i.e. the all-WT
+  collapse described above.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (test AUC 0.742). `plots/training_curves.png` — loss/acc/AUC vs epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; `logs/out.txt` — flags, split/leakage info, per-epoch trace.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/neural_networks/bilstm_subject_eval_independent/README.md
+++ b/results/legacy/neural_networks/bilstm_subject_eval_independent/README.md
@@ -1,0 +1,65 @@
+# bilstm_subject_eval_independent — BiLSTM · subject-independent
+
+**Status:** archived — superseded by `results/neural_networks/bilstm_subject_eval_independent_baseline`.
+
+> BiLSTM on chronological per-syllable sequences, evaluated **leak-free** (split grouped by mouse) — but the model collapsed to predicting WT for nearly everyone.
+
+## Overview
+- **Model:** BiLSTM (~149K params), trained on per-syllable sequences with order preserved (input is a
+  chronological sequence per session, not the 48 aggregated tabular features). `pos_weight=0.286`.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--group-split`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** 442 sessions from 119 mice (WT 336 / HT 106); `MAX_SEQ_LEN=256` (sequence lengths
+  min 1 / median 236 / max 1202). Scored at **session level**: 247 train / 91 val / 104 test sessions
+  (test = 24 held-out mice, WT 72% / HT 28%).
+- **Training:** early stopping at epoch 17/50 (best val AUC 0.659); train accuracy 0.785.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.728 | 1.000 | — |
+| Recall | 1.000 | 0.034 | — |
+| F1 | 0.843 | 0.067 | weighted **0.626** |
+| Accuracy | | | **0.731** (train 0.785) |
+
+Test AUC-ROC 0.796. WT support 75 sessions, HT support 29 — note the test split is WT-majority at the
+session level, so "predict WT" alone scores 0.72 accuracy.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.731 | 0.733 | −0.002 |
+| Weighted F1 | 0.626 | 0.749 | −0.123 |
+| WT F1 | 0.843 | 0.785 | +0.058 |
+| HT F1 | 0.067 | 0.649 | −0.582 |
+| HT recall | 0.034 | 0.940 | −0.906 |
+| HT precision | 1.000 | 0.496 | +0.504 |
+
+*Comparison is directional, not like-for-like: this NN is scored on ~104 session-level sequences,
+whereas the tabular base model is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse:** the model predicts WT for almost everyone — WT recall 1.000, HT recall 0.034
+  (1 of 29 HT sessions correct), HT F1 0.067. The headline 0.731 accuracy is an artifact of the
+  WT-majority test split, not real class separation.
+- **Validation never improved:** best val AUC peaked at 0.659 in epoch 2 and decayed thereafter while
+  train loss kept falling — overfitting/collapse rather than learning a useful WT vs HT boundary.
+- The "good-looking" deltas (WT F1 +0.058, HT precision +0.504) are entirely a side effect of the
+  collapse: by labelling nearly all sessions WT on a WT-heavy test set, WT metrics inflate while HT
+  detection is destroyed (HT recall −0.906, HT F1 −0.582). Macro F1 is only 0.455.
+- Test AUC 0.796 vs best val AUC 0.659 — the ranking signal is weak and unstable; the chosen 0.5
+  decision threshold lands almost entirely on one class.
+
+## Recommendations
+- Do not use this run; it is a collapsed baseline. The balanced-minibatch sampler config (`D`) is the
+  most reliable fix for this failure mode; see the current
+  `results/neural_networks/bilstm_subject_eval_independent_baseline`.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC. `plots/training_curves.png` — loss/accuracy/AUC per epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/neural_networks/cnn1d_subject_eval_dependent/README.md
+++ b/results/legacy/neural_networks/cnn1d_subject_eval_dependent/README.md
@@ -1,0 +1,64 @@
+# cnn1d_subject_eval_dependent — 1D-CNN · subject-dependent
+
+**Status:** archived — superseded by `results/neural_networks/cnn1d_subject_eval_dependent_baseline`.
+
+> 1D-CNN over per-syllable sequences, evaluated **session-level** on a leaky (row-level) random split.
+
+## Overview
+- **Model:** 1D-CNN (86,041 params) over a chronological per-syllable sequence (order preserved,
+  `MAX_SEQ_LEN=256`), unlike the tabular base model's 48 aggregated per-recording features.
+- **Evaluation split:** subject-dependent — random **session-level** split (`group_split=false`), so the
+  same mouse leaks across train/val/test (the log warns of 61 shared mice between train and test). This
+  is the optimistic, leakage-prone setting.
+- **Dataset:** legacy pre-baseline cache (`segmentation_classification_all_data.csv`) — 442 sessions
+  from 119 mice (WT=336, HT=106), **not** the Issue-#46 baseline data. Scored at **session level**:
+  test = 89 sessions (WT 68 / 76%, HT 21 / 24%).
+- **Training:** `pos_weight=0.320` class weighting, early-stopped at epoch 33/50 (best val AUC 0.638).
+- **Label note:** this run encodes **class 0 = HT, class 1 = WT** (inverted vs the baseline convention);
+  numbers below are reported per genotype, not per raw class index.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.808 | 0.297 | — |
+| Recall | 0.618 | 0.524 | — |
+| F1 | 0.700 | 0.379 | weighted **0.624** |
+| Accuracy | | | **0.596** (train 0.822) |
+
+Test AUC 0.653. Confusion matrix counts (rows = true, cols = pred): `[[HT→HT 11, HT→WT 10], [WT→HT 26, WT→WT 42]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.596 | 0.733 | −0.137 |
+| Weighted F1 | 0.624 | 0.749 | −0.125 |
+| WT F1 | 0.700 | 0.785 | −0.085 |
+| HT F1 | 0.379 | 0.649 | −0.270 |
+| HT recall | 0.524 | 0.940 | −0.416 |
+| HT precision | 0.297 | 0.496 | −0.199 |
+
+*Directional only: this NN is scored on ~89 session-level sequences from a legacy cache, while the
+tabular base is scored on ~2,465 recording-level rows of the Issue-#46 baseline data — not a like-for-like comparison.*
+
+## Key insights
+- The 1D-CNN underperforms the tabular base on every metric: accuracy 0.596 (−0.137), weighted F1 0.624
+  (−0.125). Both the dataset (legacy cache, not baseline) and the unit (sessions, not recordings) differ,
+  so treat the gap as directional.
+- No degenerate collapse — both classes get predicted (HT recall 0.524, WT recall 0.618) — but minority
+  detection is weak: **HT precision 0.297 / F1 0.379**, with 10 of 21 HT sessions called WT and only 11
+  of 37 HT predictions correct.
+- Heavy overfit despite the leaky split: train accuracy 0.822 / train AUC 0.941 vs test accuracy 0.596 /
+  test AUC 0.653, and val accuracy swung erratically (0.36–0.72 across epochs), never tracking train.
+- AUC 0.653 shows only modest ranking signal; the small 89-session test set makes per-class metrics noisy.
+
+## Recommendations
+- Use the superseding `results/neural_networks/cnn1d_subject_eval_dependent_baseline` run (Issue-#46
+  baseline data, corrected labels) for any current 1D-CNN comparison; do not cite these legacy numbers.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC. `plots/training_curves.png` — loss/accuracy/AUC over 33 epochs.
+- `model/cnn1d_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; `logs/out.txt` — flags, split info, class balance, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/neural_networks/cnn1d_subject_eval_independent/README.md
+++ b/results/legacy/neural_networks/cnn1d_subject_eval_independent/README.md
@@ -1,0 +1,70 @@
+# cnn1d_subject_eval_independent — 1D-CNN · subject-independent
+
+**Status:** archived — superseded by `results/neural_networks/cnn1d_subject_eval_independent_baseline`.
+
+> 1D-CNN on chronological per-syllable sequences, evaluated **leak-free** (split grouped by mouse) — collapses to a near-random, below-majority-baseline operating point.
+
+## Overview
+- **Model:** 1D-CNN (~86K params; convolutions over an ordered per-syllable sequence, MAX_SEQ_LEN=256).
+  Unlike the tabular base (48 aggregated per-recording features), the input is a chronological syllable
+  sequence and the model is scored at **session level**.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--group-split`), so no
+  mouse appears in two sets. Honest "generalize to unseen mice" setting (harder than the dependent base
+  model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** legacy external cache (`segmentation_classification_all_data.csv`), 442 sessions from
+  119 mice (WT=336, HT=106). Train 247 / Val 91 / Test 104 sessions. Test = 24 held-out mice
+  (WT 72% / HT 28%) — this run predates the Issue-#46 baseline filters and the HET→WT correction.
+- **What was adapted vs the base model:** two levers change together — model family (1D-CNN instead of
+  XGBoost) **and** evaluation moves from subject-dependent (recordings) to subject-independent (sessions).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.789 | 0.318 | — |
+| Recall | 0.400 | 0.724 | — |
+| F1 | 0.531 | 0.442 | weighted **0.506** |
+| Accuracy | | | **0.490** (train 0.623) |
+
+AUC 0.550 (test) vs 0.908 (train); best val AUC 0.575; early stopping at epoch 29/50.
+Confusion matrix (rows = true, cols = pred; class 0 = HT support 29, class 1 = WT support 75):
+`[[HT→0 21, HT→1 8], [WT→0 45, WT→1 30]]` — 66 of 104 sessions are pushed onto the minority label.
+(`logs/out.txt` and the plot headers label "HT (0)/WT (1)"; the supports (HT 29 / WT 75) and the data
+stats — WT majority — confirm class 0 = HT, class 1 = WT.)
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.490 | 0.733 | −0.243 |
+| Weighted F1 | 0.506 | 0.749 | −0.243 |
+| WT F1 | 0.531 | 0.785 | −0.254 |
+| HT F1 | 0.442 | 0.649 | −0.207 |
+| HT recall | 0.724 | 0.940 | −0.216 |
+| HT precision | 0.318 | 0.496 | −0.178 |
+
+*Directional comparison only: this NN is scored on ~104 session-level sequences, while the tabular base
+is scored on ~2,465 recording-level rows — not a like-for-like split.*
+
+## Key insights
+- **Below the majority-class baseline.** Test accuracy 0.490 is *worse* than always-guessing-WT (0.72 on
+  this test mix), and test AUC 0.550 is barely above chance while train AUC is 0.908 — severe
+  overfitting that does not transfer to unseen mice.
+- **Collapse toward the minority label.** The model predicts class 0 (HT) for 66 of 104 sessions, so
+  WT recall craters to 0.400 (45 of 75 WT sessions misclassified) and HT recall (0.724) is bought only
+  by spraying HT predictions — HT precision is just 0.318.
+- **Sequence model adds nothing here.** Every headline metric is 0.18–0.25 below the tabular base; the
+  1D-CNN does not learn a usable WT/HT boundary from ordered syllables on this leak-free split.
+
+## Recommendations
+- Do not use this run for any performance estimate — it is below the trivial baseline. Prefer the
+  current baseline NN and tabular subject-independent runs under `results/`.
+- For the small independent split, the collapse points at the standard NN fixes (config D balanced
+  minibatch sampler, config F regsmall regularization); this control run did neither.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png`, `plots/training_curves.png` — ROC and loss/accuracy/AUC curves.
+- `model/cnn1d_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- `results.json` — metrics, config, split sizes. `logs/out.txt` — flags, split info, class balance, epoch log.
+- Metrics source: `results.json` + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/neural_networks/transformer_subject_eval_dependent/README.md
+++ b/results/legacy/neural_networks/transformer_subject_eval_dependent/README.md
@@ -1,0 +1,62 @@
+# transformer_subject_eval_dependent — Transformer · subject-dependent
+
+**Status:** archived — superseded by `results/neural_networks/transformer_subject_eval_dependent_baseline`.
+
+> Sequence Transformer on per-syllable USV sequences, scored at session level; collapses toward predicting HT for almost everyone.
+
+## Overview
+- **Model:** Transformer (~72.5K params) over chronological per-syllable sequences (`MAX_SEQ_LEN=256`),
+  unlike the tabular base's 48 aggregated per-recording features. Scored at the session level.
+- **Evaluation split:** subject-dependent — random session-level split (`group_split=false`), so mice
+  leak across sets (the log warns: 61 shared mice train/test, 57 train/val). Optimistic by construction.
+- **Dataset:** legacy external CSV cache (`segmentation_classification_all_data.csv`) — 442 sessions
+  from 119 mice (WT 336 / HT 106 ≈ 24% positive); pre-dates the official Issue-#46 baseline filters.
+- **Run:** train 264 / val 89 / test 89 sessions (each ~76% WT / 24% HT). Trained with `pos_weight=0.320`,
+  early-stopped at epoch 23/50 (best val AUC 0.695).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.889 | 0.268 | — |
+| Recall | 0.235 | 0.905 | — |
+| F1 | 0.372 | 0.413 | weighted **0.382** |
+| Accuracy | | | **0.393** (train 0.405) · test AUC 0.754 |
+
+Support: WT 68, HT 21 (89 test sessions). Note `results.json` labels its class keys `0.0`/`1.0` swapped
+relative to the support counts; figures above follow the support-correct WT=68 / HT=21 mapping.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.393 | 0.733 | −0.340 |
+| Weighted F1 | 0.382 | 0.749 | −0.367 |
+| WT F1 | 0.372 | 0.785 | −0.413 |
+| HT F1 | 0.413 | 0.649 | −0.236 |
+| HT recall | 0.905 | 0.940 | −0.035 |
+| HT precision | 0.268 | 0.496 | −0.228 |
+
+NN are scored on session-level sequence data (89 test sessions here) vs the tabular base's recording-level
+data (~2,465 rows), so this comparison is directional, not like-for-like.
+
+## Key insights
+- **Degenerate collapse.** The model predicts HT for almost everyone: HT recall 0.905 with WT recall only
+  0.235. It calls most sessions positive, so accuracy (0.393) falls *below* a majority-class baseline.
+- **AUC vs accuracy mismatch.** Test AUC 0.754 says the ranking carries real signal, but the chosen
+  operating point is badly miscalibrated — the decision threshold sits where nearly all sessions tip to HT.
+- **No fit, not just bad calibration.** Train accuracy 0.405 ≈ test 0.393; the model never learned the
+  WT class even on the (leaky) training data. `pos_weight=0.320` plus the tiny 264-session train set drove
+  the collapse rather than overfitting.
+- Despite subject-dependent leakage (61 shared train/test mice), which usually inflates scores, this run
+  lands far under the tabular base — the failure is the model, not the split.
+
+## Recommendations
+- Treat this as a known-bad headline NN run. Use the current `transformer_subject_eval_dependent_baseline`
+  on the official Issue-#46 data, and prefer the balanced-minibatch-sampler (D) configs that fix collapse.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (AUC 0.754). `plots/training_curves.png` — loss/acc/AUC across 23 epochs.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split/training detail in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/neural_networks/transformer_subject_eval_independent/README.md
+++ b/results/legacy/neural_networks/transformer_subject_eval_independent/README.md
@@ -1,0 +1,68 @@
+# transformer_subject_eval_independent — Transformer · subject-independent
+
+**Status:** archived — superseded by `results/neural_networks/transformer_subject_eval_independent_baseline`.
+
+> Sequence Transformer evaluated **leak-free** (split grouped by mouse) — degenerates into
+> over-predicting the minority (HT) class and barely beats chance.
+
+## Overview
+- **Model:** Transformer (~73K params) over the **chronological per-syllable sequence** for each
+  session (order preserved, `MAX_SEQ_LEN=256`), not the 48 aggregated per-recording tabular features.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--group-split`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** legacy NN cache (`segmentation_classification_all_data.csv`), **442 sessions from
+  119 mice**, WT=336 / HT=106. Scored at **session level**: 247 train / 91 val / **104 test** sessions
+  (test = 24 mice, WT 75 / HT 29). This pre-dates the official Issue-#46 baseline filters and the
+  April-2026 HET→WT correction.
+- **What was adapted vs the base model:** three levers change together — model family (Transformer
+  instead of XGBoost), input granularity (per-syllable sequence vs aggregated features), **and**
+  evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.841 | 0.367 | — |
+| Recall | 0.493 | 0.759 | — |
+| F1 | 0.622 | 0.494 | weighted **0.586** |
+| Accuracy | | | **0.567** (train 0.567) |
+
+Test AUC 0.653 · best val AUC 0.619 · 19 epochs (early-stopped). Support: WT 75 / HT 29 sessions.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.567 | 0.733 | −0.166 |
+| Weighted F1 | 0.586 | 0.749 | −0.163 |
+| WT F1 | 0.622 | 0.785 | −0.163 |
+| HT F1 | 0.494 | 0.649 | −0.155 |
+| HT recall | 0.759 | 0.940 | −0.181 |
+| HT precision | 0.367 | 0.496 | −0.129 |
+
+*Directional only: this NN is scored on session-level sequence data (~104 test sessions) while the
+tabular base is scored on recording-level rows (~2,465), so the comparison is not like-for-like.*
+
+## Key insights
+- **Degenerate bias toward the minority class.** The model over-predicts HT, not WT: WT recall is only
+  0.493 while HT recall is 0.759 with HT precision just 0.367 — it tags ~3 in 4 minority pups but is wrong
+  on ~2 of every 3 HT calls (it predicts HT ~60 times vs WT ~44, even though WT is the majority). Overall
+  accuracy 0.567 is **below** the 0.72 WT base rate — a trivial "always-WT" classifier would beat it.
+- **No real learning.** Train accuracy 0.567 ≈ test accuracy 0.567 and val AUC peaked at 0.619 by
+  epoch 4, then drifted down until early stopping at epoch 19. Test AUC 0.653 indicates only weak
+  ranking signal; the Transformer never fit the training sessions either.
+- **Worse than the tabular base on every axis** (accuracy/F1/recall/precision all down ~0.13–0.18),
+  consistent with the small leak-free split (only 247 train / 104 test sessions, 71 train mice) being
+  too little data for a sequence Transformer.
+
+## Recommendations
+- Prefer the balanced-minibatch-sampler config (`D`) and the regularized small net (`F`) for this tiny
+  independent split; control runs like this collapse. For an honest unseen-mouse estimate, use the
+  current `results/neural_networks/` baseline runs rather than this superseded cache.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.653). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_dependent_baseline/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,57 @@
+# xgboost_strain1_subject_eval_dependent_baseline — XGBoost · subject-dependent · strain1
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned legacy XGBoost on the strain1 cohort only, evaluated subject-dependent (rows leak across train/test).
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no hyperparameter search). Class imbalance handled with
+  `sample_weight=balanced` and `scale_pos_weight=3.5195` (n_WT/n_HT, HT positive).
+- **Evaluation split:** subject-dependent — random **row-level** split, so the same mouse appears in
+  train, val and test (the log warns 59 shared mice across all three sets). This leaks and is optimistic.
+- **Cohort:** strain1 only (years 2022–2024, mixed BALB/C+C57 background). The strain filter kept
+  7,323/11,974 rows (`pup_strain == 1`), 59 mice; `pup_gen` balance 5,683 WT / 1,640 HT.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), strain1 subset.
+  Train 4,393 / Val 1,465 / Test 1,465 rows; test WT 77.1% / HT 22.9%.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.996 | 0.483 | — |
+| Recall | 0.685 | 0.991 | — |
+| F1 | 0.812 | 0.650 | weighted **0.774** |
+| Accuracy | | | **0.755** (train 0.759) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 773, WT→HT 356], [HT→WT 3, HT→HT 333]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.755 | 0.733 | +0.022 |
+| Weighted F1 | 0.774 | 0.749 | +0.025 |
+| WT F1 | 0.812 | 0.785 | +0.027 |
+| HT F1 | 0.650 | 0.649 | +0.001 |
+| HT recall | 0.991 | 0.940 | +0.051 |
+| HT precision | 0.483 | 0.496 | −0.013 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Restricting to the strain1 cohort nudges every headline number up a touch (accuracy +0.022, weighted
+  F1 +0.025) vs the all-cohort dependent base — but this is still a **leaky** split (59 mice shared
+  across train/val/test), so the numbers are optimistic, not a generalization estimate.
+- The model is near-degenerate toward the minority class: **HT recall 0.991** (it misses only 3 of 336
+  HT pups) but at the cost of flooding WT with false positives — 356 of 1,129 true WT are called HT.
+- Class separation stays poor — **HT precision 0.483** (about half of HT predictions are wrong), so
+  HT F1 (0.650) is essentially tied with the base (+0.001) despite the higher recall.
+- Train 0.759 vs test 0.755 sit almost on top of each other; with row-level leakage a tight train/test
+  gap is expected and does not indicate good generalization.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — training/eval curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_dependent_external/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_dependent_external/README.md
@@ -1,0 +1,47 @@
+# xgboost_strain1_subject_eval_dependent_external — XGBoost · subject-dependent · strain1 (external)
+
+**Status:** archived — superseded by the current `--baseline` runs under `results/`.
+
+> Untuned legacy XGBoost on the external strain1 cohort, evaluated subject-**dependent** (rows split randomly, mice leak across train/test).
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no hyperparameter search).
+- **Cohort:** strain1 (years 2022–2024, mixed BALB/C + C57 background), pulled from the externally-validated dataset (`--external --strain 1`); the strain filter keeps 8,616 / 13,625 rows and 70 mice.
+- **Evaluation split:** subject-dependent — random **row-level** split (train 5,169 / val 1,723 / test 1,724). The log flags `mouse overlap -- train/test: 70 shared mice`, so the same mouse appears in train and test: this is the optimistic, leak-prone setting (like the base model).
+- **Class balance:** this run inverts the label convention — class 0 = HET/HT (ASD-model, minority 23.0% of test), class 1 = WT (control, majority 77.0%). Read the per-class numbers below by genotype, not by index.
+- **What differs vs the base model:** same untuned recipe and dependent split, but a different data source (external) and only the strain1 sub-cohort instead of the full baseline data.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.985 | 0.473 | — |
+| Recall | 0.680 | 0.965 | — |
+| F1 | 0.804 | 0.635 | weighted **0.766** |
+| Accuracy | | | **0.745** (train 0.772) |
+
+Confusion matrix (rows = true, cols = pred; class 0 = HT, class 1 = WT): `[[HT→HT 382, HT→WT 14], [WT→HT 425, WT→WT 903]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.745 | 0.733 | +0.012 |
+| Weighted F1 | 0.766 | 0.749 | +0.017 |
+| WT F1 | 0.804 | 0.785 | +0.019 |
+| HT F1 | 0.635 | 0.649 | −0.014 |
+| HT recall | 0.965 | 0.940 | +0.025 |
+| HT precision | 0.473 | 0.496 | −0.023 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the dependent split the strain1 external cohort edges the base model on headline metrics — accuracy 0.745 (+0.012) and weighted F1 0.766 (+0.017) — but this is the leaky setting, so treat the gain as optimistic, not honest generalization.
+- The operating point is heavily skewed toward calling HT: **HT recall 0.965** (catches almost every ASD-model pup) but **HT precision 0.473** (more than half of HT calls are false positives). The confusion matrix confirms it — 425 of 1,328 true WT are mislabeled HT.
+- WT precision is near-perfect (0.985) while WT recall sags to 0.680: when the model says WT it is almost always right, but it under-calls the majority class to chase HT recall.
+- Train 0.772 vs test 0.745 is a tight 0.027 gap — little overfitting — but with mice leaking across the split that closeness overstates real-world performance.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices. `plots/AUC_error.png` — train/val AUC learning curve. `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, data source, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_independent_baseline/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_independent_baseline/README.md
@@ -1,0 +1,69 @@
+# xgboost_strain1_subject_eval_independent_baseline — XGBoost · subject-independent · strain1
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned legacy XGBoost on the strain1 cohort, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe; balanced sample weights, `scale_pos_weight=3.31`).
+- **Cohort:** strain1 — years 2022–2024, mixed BALB/C + C57 background. Strain filter kept
+  7,323/11,974 rows (`pup_strain == 1`), 59 mice.
+- **Evaluation split:** subject-independent — group-aware split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Train 4,068 rows / 35 mice, Val 1,433 rows / 12 mice, Test 1,822 rows / 12 mice
+  (test WT 79.6% / HT 20.4%).
+- **What was adapted vs the base model:** two levers change together — cohort is restricted to strain1
+  **and** evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.893 | 0.401 | — |
+| Recall | 0.751 | 0.651 | — |
+| F1 | 0.816 | 0.496 | weighted **0.751** |
+| Accuracy | | | **0.731** (train 0.856) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1089, WT→HT 361], [HT→WT 130, HT→HT 242]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.731 | 0.733 | −0.002 |
+| Weighted F1 | 0.751 | 0.749 | +0.002 |
+| WT F1 | 0.816 | 0.785 | +0.031 |
+| HT F1 | 0.496 | 0.649 | −0.153 |
+| HT recall | 0.651 | 0.940 | −0.289 |
+| HT precision | 0.401 | 0.496 | −0.095 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Headline numbers look flat — accuracy 0.731 (−0.002) and weighted F1 0.751 (+0.002) sit on top of the
+  dependent base — but that parity is carried entirely by the WT majority; the leak-free split costs the
+  minority class heavily.
+- The minority class collapses: **HT recall falls to 0.651** (−0.289 vs base) and **HT precision to
+  0.401** (−0.095), dragging HT F1 to 0.496 (−0.153). The model misses ~1 in 3 ASD-model pups and is
+  wrong on ~6 of every 10 HT calls it makes.
+- The strain1-only restriction (mixed BALB/C + C57 background, 59 mice) plus by-mouse grouping leaves a
+  small, heterogeneous training set; the untuned recipe overfits, with train 0.856 vs test 0.731
+  (0.125 gap).
+- WT F1 actually improves (+0.031): the conservative shift on HT trades minority recall for cleaner
+  majority calls (WT precision 0.893).
+
+## Recommendations
+- HT detection is too weak at the default 0.5 cut for any deployment use; prefer the tuned independent
+  recipe (`xgboost_tuned_independent`, heavily regularized/shallow) over this untuned one for the
+  leak-free setting.
+- Use the current full-cohort `--baseline` runs under `results/tabular_models/` for honest
+  new-mouse estimates; this strain1-only archived run narrows the data and is superseded.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC / error learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_independent_external/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain1_subject_eval_independent_external/README.md
@@ -1,0 +1,70 @@
+# xgboost_strain1_subject_eval_independent_external — XGBoost · subject-independent · strain1 (external)
+
+**Status:** archived — superseded by the current `--baseline` runs under `results/`.
+
+> Untuned legacy XGBoost on the strain1 external cohort, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no 200-trial search applied).
+- **Evaluation split:** subject-independent — group-aware train/val/test split **by mouse**
+  (`--independent`), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak across
+  train/test).
+- **Dataset:** legacy **external** data (`outputs/external/aggregated/all_data_external_main.csv`),
+  **not** the official Issue-#46 baseline. Strain filter kept 8,616 / 13,625 rows
+  (`pup_strain == 1`, the 2022–2024 mixed BALB/C+C57 cohort), 70 mice. `pup_gen` balance WT 6,624 /
+  HT 1,992.
+- **Label encoding (legacy/external):** class 0 = HT/HET (ASD-model, minority positive),
+  class 1 = WT — the **opposite** of the baseline convention. Test = 1,750 recordings from 14 held-out
+  mice (WT 82.3% / HT 17.7%).
+- **What was adapted vs the base model:** three levers change together — external dataset (not baseline),
+  strain1-only cohort, **and** evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.994 | 0.359 | — |
+| Recall | 0.623 | 0.984 | — |
+| F1 | 0.766 | 0.526 | weighted **0.724** |
+| Accuracy | | | **0.687** (train 0.813) |
+
+Confusion matrix (rows = true, cols = pred; legacy order HT then WT):
+`[[HT→HT 304, HT→WT 5], [WT→HT 543, WT→WT 898]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.687 | 0.733 | −0.046 |
+| Weighted F1 | 0.724 | 0.749 | −0.025 |
+| WT F1 | 0.766 | 0.785 | −0.019 |
+| HT F1 | 0.526 | 0.649 | −0.123 |
+| HT recall | 0.984 | 0.940 | +0.044 |
+| HT precision | 0.359 | 0.496 | −0.137 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The model **leans degenerate toward the minority class**: HT recall 0.984 (only 5 of 309 HT pups
+  missed) but WT recall collapses to 0.623 — it predicts HT for far too many WT pups
+  (543 WT→HT false positives), which is why HT precision is just 0.359.
+- The harder leak-free split plus the strain1-only external cohort drops overall accuracy to 0.687
+  (−0.046 vs base) and weighted F1 to 0.724 (−0.025); the test set is also heavily WT-skewed
+  (82.3%), so high HT recall comes cheap.
+- Class separation is poor — **HT F1 0.526** (−0.123 vs base), driven entirely by precision; about two
+  of every three HT calls are false alarms.
+- Train 0.813 vs test 0.687 (0.13 gap) reflects the cost of unseen mice on this untuned recipe.
+
+## Recommendations
+- Do not use this archived external run for reporting; prefer the current `--baseline` XGBoost runs
+  under `results/tabular_models/`, which apply the Issue-#46 filters and the HET→WT label correction.
+- If revisited, the operating point needs rebalancing (threshold tuning / regularization) — at the
+  default 0.5 cut it sacrifices nearly 40% of WT pups to chase HT recall.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — train/val AUC error curve.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_dependent_baseline/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,57 @@
+# xgboost_strain2_subject_eval_dependent_baseline — XGBoost · subject-dependent · strain2
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned legacy XGBoost on the pure BALB/c strain2 cohort only, evaluated subject-dependent (leaky row-level split).
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe; `sample_weight=balanced`, `scale_pos_weight=2.4108`).
+- **Evaluation split:** subject-dependent — random row-level split (`Strategy: random`), so the same mouse
+  appears in train, val and test (the log warns `mouse overlap -- train/test: 47 shared mice`). This is
+  the optimistic, leaky setting, the same family as the base model.
+- **Cohort:** strain2 only — pure BALB/c classic published cohort (years 2015/2018). The strain filter
+  keeps 4,651/11,974 rows (`pup_strain == 2`) across 47 mice.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 931 recordings (WT 71.2% / HT 28.8%); train 2,790 / val 930.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.952 | 0.464 | — |
+| Recall | 0.566 | 0.929 | — |
+| F1 | 0.710 | 0.619 | weighted **0.683** |
+| Accuracy | | | **0.670** (train 0.741) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 375, WT→HT 288], [HT→WT 19, HT→HT 249]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.670 | 0.733 | −0.063 |
+| Weighted F1 | 0.683 | 0.749 | −0.066 |
+| WT F1 | 0.710 | 0.785 | −0.075 |
+| HT F1 | 0.619 | 0.649 | −0.030 |
+| HT recall | 0.929 | 0.940 | −0.011 |
+| HT precision | 0.464 | 0.496 | −0.032 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Restricting to the strain2 cohort costs accuracy across the board even in this leaky split: test
+  accuracy 0.670 (−0.063) and weighted F1 0.683 (−0.066) both trail the full-data dependent base model.
+- The operating point is the familiar over-predict-HT pattern: **HT recall 0.929** but **HT precision
+  0.464** — over half of HT calls are false positives, and WT recall collapses to 0.566 (375/663),
+  with 288 WT recordings misclassified as HT.
+- HT precision drops 0.032 vs base; with only ~4.7K rows from 47 mice, the smaller strain2 cohort gives
+  XGBoost less signal than the full baseline, so class separation is weaker, not stronger.
+- The train→test gap is modest (0.741 → 0.670), but that is on a leaky split — the dependent setting
+  flatters generalization, so treat these numbers as an upper bound.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — training curve / AUC error. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_dependent_external/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_dependent_external/README.md
@@ -1,0 +1,62 @@
+# xgboost_strain2_subject_eval_dependent_external — XGBoost (untuned) · subject-dependent · strain2 (external)
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned XGBoost on the externally-validated strain2 (pure BALB/c, 2015/2018) cohort, evaluated leaky (random row-level split).
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe.
+- **Evaluation split:** subject-dependent — random **row-level** split (`Strategy: random`), so the same
+  mouse appears in train, val and test (the log warns of 49–50 shared mice across every pair). This is the
+  optimistic, leaky setting, same family as the base model.
+- **Dataset:** externally-validated set (`--external`) filtered to **strain2** (`--strain 2`, pure BALB/c
+  classic 2015/2018 cohort): kept 5,009/13,625 rows, 50 mice. This predates the official Issue-#46 baseline
+  filters and the April-2026 HET→WT correction.
+- **Class encoding (note):** this legacy run flips the label convention — **class 0 = HET** (the ASD-model
+  minority, 30.8% of test, support 309) and **class 1 = WT** (majority, 69.2%, support 693). Metrics below
+  are reported by genotype, not class id.
+- **What was adapted vs the base model:** restricted to the strain2 external cohort instead of the full
+  baseline data; model family and the leaky dependent split are unchanged.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.918 | 0.569 | — |
+| Recall | 0.710 | 0.858 | — |
+| F1 | 0.801 | 0.684 | weighted **0.765** |
+| Accuracy | | | **0.755** (train 0.811) |
+
+Confusion matrix (rows = true, cols = pred; class 0 = HET, class 1 = WT): `[[HT→HT 265, HT→WT 44], [WT→HT 201, WT→WT 492]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.755 | 0.733 | +0.022 |
+| Weighted F1 | 0.765 | 0.749 | +0.016 |
+| WT F1 | 0.801 | 0.785 | +0.016 |
+| HT F1 | 0.684 | 0.649 | +0.035 |
+| HT recall | 0.858 | 0.940 | −0.082 |
+| HT precision | 0.569 | 0.496 | +0.073 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the pure-BALB/c strain2 cohort the untuned model edges out the base on most aggregate metrics
+  (accuracy +0.022, weighted F1 +0.016, HT F1 +0.035) — the cleaner single-strain data is easier to
+  separate, but this is still a leaky dependent split so the figures are optimistic.
+- The operating point is less aggressive on the minority class than the base: **HT recall drops to 0.858**
+  (−0.082), so ~14% of ASD-model pups are missed, while **HT precision rises to 0.569** (+0.073) — fewer
+  false positives among HT calls than the base's 0.496.
+- Class separation is still weak: **HT precision ≈ 0.57** means roughly four in ten HT predictions are
+  wrong; the 201 WT→HT false positives dominate the error budget.
+- Train 0.811 vs test 0.755 (0.056 gap) is modest, but the 49–50 shared mice across splits mean the test
+  score reflects memorized mice, not generalization to new animals.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices (single-strain run, no
+  per-strain split). `plots/AUC_error.png` — training/AUC curve.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_model.pkl` — fitted model. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_independent_baseline/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_independent_baseline/README.md
@@ -1,0 +1,69 @@
+# xgboost_strain2_subject_eval_independent_baseline — XGBoost · subject-independent · strain2
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned legacy XGBoost on the pure-BALB/c strain2 cohort, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no hyperparameter search; `sample_weight=balanced`,
+  `scale_pos_weight=2.069` = n_WT/n_HT with HT as positive).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware by `mouse_idx`), so no mouse appears in two sets. This is the honest "generalize to
+  unseen mice" setting (harder than the dependent base model, which splits rows randomly and lets
+  mice leak across train/test).
+- **Cohort:** strain2 = years 2015/2018, the pure BALB/c classic published cohort. Strain filter kept
+  4,651/11,974 rows (`pup_strain == 2`), 47 mice.
+- **Dataset:** official baseline (`all_data_external_baseline.csv`; Issue #46 filters; April-2026
+  HET→WT correction). Test = 1,119 recordings from 10 held-out mice (WT 76.9% / HT 23.1%);
+  train 2,452 rows / 27 mice, val 1,080 rows / 10 mice.
+- **What was adapted vs the base model:** two levers change together — cohort is restricted to strain2
+  **and** evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.855 | 0.401 | — |
+| Recall | 0.740 | 0.581 | — |
+| F1 | 0.793 | 0.475 | weighted **0.720** |
+| Accuracy | | | **0.703** (train 0.842) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 637, WT→HT 224], [HT→WT 108, HT→HT 150]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.703 | 0.733 | −0.030 |
+| Weighted F1 | 0.720 | 0.749 | −0.029 |
+| WT F1 | 0.793 | 0.785 | +0.008 |
+| HT F1 | 0.475 | 0.649 | −0.174 |
+| HT recall | 0.581 | 0.940 | −0.359 |
+| HT precision | 0.401 | 0.496 | −0.095 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Overall accuracy (0.703) and weighted F1 (0.720) land ~0.030 below the dependent base model — a
+  modest top-line drop, but the per-class picture is much worse than the headline suggests.
+- The minority class collapses on unseen mice: **HT recall 0.581** (−0.359 vs base) and **HT precision
+  0.401** (−0.095), so HT F1 falls to 0.475 (−0.174). The model misses ~42% of ASD-model pups and is
+  wrong on ~60% of the HT calls it does make.
+- WT carries the accuracy: WT F1 0.793 (+0.008 vs base) holds up, so the strain2 + leak-free regime
+  trades almost all of its loss out of the positive class.
+- Train 0.842 vs test 0.703 (0.14 gap) reflects the cost of unseen mice on the smaller pure-BALB/c
+  cohort (only 27 train mice), with no tuning to regularize the split.
+
+## Recommendations
+- Use the current full-baseline runs under `results/tabular_models/`, not this strain2-only legacy run,
+  for any reported performance — this folder is archived.
+- If a strain2 estimate is still needed, HT recall (0.581) is too low at the default 0.5 cut for a
+  screening use case; a tuned/regularized independent recipe and threshold tuning would be required
+  before trusting positive calls.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC / error learning curve.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_independent_external/README.md
+++ b/results/legacy/tabular_models/strain/xgboost_strain2_subject_eval_independent_external/README.md
@@ -1,0 +1,63 @@
+# xgboost_strain2_subject_eval_independent_external — XGBoost · subject-independent · strain2 (external)
+
+**Status:** archived — superseded by the current `--baseline` runs under `results/`.
+
+> Untuned XGBoost on the strain2 (2015/2018 BALB/c) external cohort, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** plain XGBoost (untuned legacy recipe; no hyperparameter search).
+- **Evaluation split:** subject-independent — group-aware split **by mouse** (`--independent`), so no mouse
+  appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the dependent
+  base model, which splits rows randomly and lets mice leak across train/test).
+- **Cohort / dataset:** strain2 = 2015/2018 pure BALB/c classic published cohort, on the early external
+  dataset (`outputs/external/aggregated/all_data_external_main.csv`, pre-Issue-#46 / pre-April-2026
+  correction). Strain filter kept 5,009/13,625 rows (50 mice).
+- **Label convention here is inverted vs the base model:** in this legacy run class 0 = HET (ASD model)
+  and class 1 = WT. Test = 751 recordings from 10 held-out mice, but the split landed very imbalanced
+  (HET only 13.6% / WT 86.4%), unlike the ~24–27% HET elsewhere.
+- **What was adapted vs the base model:** three levers change together — cohort (strain2 external instead
+  of full baseline), evaluation moves subject-dependent → subject-independent, and the train/test class
+  balance is heavily skewed by the small 10-mouse test split.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.875 | 0.158 | — |
+| Recall | 0.689 | 0.373 | — |
+| F1 | 0.771 | 0.222 | weighted **0.696** |
+| Accuracy | | | **0.646** (train 0.866) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 447, WT→HT 202], [HT→WT 64, HT→HT 38]]`
+(from the logged class-0=HET / class-1=WT matrix `[[38 64],[202 447]]`).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.646 | 0.733 | −0.087 |
+| Weighted F1 | 0.696 | 0.749 | −0.053 |
+| WT F1 | 0.771 | 0.785 | −0.014 |
+| HT F1 | 0.222 | 0.649 | −0.427 |
+| HT recall | 0.373 | 0.940 | −0.567 |
+| HT precision | 0.158 | 0.496 | −0.338 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The minority HET class essentially **collapses**: HT recall 0.373 and HT precision 0.158 (HT F1 0.222,
+  −0.427 vs base). The model finds only 38 of 102 true HET pups and is wrong on 84% of its HET calls.
+- The honest leak-free split on a tiny 10-mouse test set is brutal: overall accuracy 0.646 (−0.087) and
+  weighted F1 0.696 (−0.053) sit well below the dependent base, and the 13.6% HET test balance means
+  accuracy is propped up almost entirely by the WT majority.
+- Train 0.866 vs test 0.646 (0.22 gap) is the cost of unseen mice plus a small, mismatched cohort — train
+  is 28.9% HET while test is only 13.6% HET.
+- This is an early external-dataset, strain2-only experiment predating the Issue-#46 filters and the
+  April-2026 HET→WT correction; treat its numbers as historical, not as a current generalization estimate.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC / error learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — XGBoost feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, data source, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/tabpfn_subject_eval_dependent/README.md
+++ b/results/legacy/tabular_models/tabpfn_subject_eval_dependent/README.md
@@ -1,0 +1,64 @@
+# tabpfn_subject_eval_dependent — TabPFN · subject-dependent
+
+**Status:** archived — superseded by `results/tabular_models/tabpfn_subject_eval_independent_baseline` (the current baseline TabPFN run).
+
+> Legacy TabPFN on the pre-baseline `all_data.csv`, evaluated with a leaky row-level split.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve and no feature-importance output).
+- **Evaluation split:** subject-dependent — `random` row-level split (train 5,709 / val 1,903 /
+  test 1,903 rows). The log explicitly warns of mouse overlap (87 shared mice across train/val,
+  train/test and val/test), so the same mouse appears in train and test — leaky and optimistic.
+- **Dataset:** legacy `outputs/aggregated/all_data.csv` — pre-baseline, before the Issue #46 filters
+  and the April-2026 HET→WT correction. Class indices are also the legacy mapping (class 0 = HT/HET,
+  class 1 = WT); test class balance is HT 30.9% / WT 69.1%, the inverse of the baseline runs.
+- **What was adapted vs the base model:** model family (TabPFN instead of XGBoost) on the old data and
+  the leaky dependent split.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.743 | 0.678 | — |
+| Recall | 0.942 | 0.272 | — |
+| F1 | 0.831 | 0.388 | weighted **0.694** |
+| Accuracy | | | **0.735** (train 0.762) |
+
+Confusion matrix (rows = true, cols = pred): `[[HT→HT 160, HT→WT 428], [WT→HT 76, WT→WT 1239]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.735 | 0.733 | +0.002 |
+| Weighted F1 | 0.694 | 0.749 | −0.055 |
+| WT F1 | 0.831 | 0.785 | +0.046 |
+| HT F1 | 0.388 | 0.649 | −0.261 |
+| HT recall | 0.272 | 0.940 | −0.668 |
+| HT precision | 0.678 | 0.496 | +0.182 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The model collapses toward the **majority class**: WT recall is 0.942 but **HT recall is only 0.272**
+  (−0.668 vs base) — it misses ~3 of every 4 ASD-model pups. The confusion matrix confirms it
+  (HT→WT 428 vs HT→HT 160).
+- Headline accuracy (0.735) matches the base model almost exactly, but that is an artifact of the
+  WT-heavy 69%/31% balance plus the leaky split — **weighted F1 drops to 0.694** (−0.055) once the
+  minority class is weighted in.
+- The operating point is the mirror image of the base model: HT precision rises to 0.678 (+0.182) only
+  because the model rarely predicts HT, trading nearly all HT recall away. HT F1 0.388 is the worst of
+  any tabular dependent run.
+- This run is doubly outdated — pre-baseline data (no Issue #46 filters, no HET→WT correction) and a
+  split with explicit train/test mouse leakage — so its numbers are not comparable to current runs.
+
+## Recommendations
+- Do not use for any performance estimate; refer to the current baseline TabPFN run
+  (`results/tabular_models/tabpfn_subject_eval_independent_baseline`) instead.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `logs/out.txt` — flags, split info, mouse-overlap warning, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/tabpfn_subject_eval_dependent_external/README.md
+++ b/results/legacy/tabular_models/tabpfn_subject_eval_dependent_external/README.md
@@ -1,0 +1,64 @@
+# tabpfn_subject_eval_dependent_external — TabPFN · subject-dependent · external dataset
+
+**Status:** archived — superseded by `results/tabular_models/tabpfn_subject_eval_dependent_baseline`.
+
+> TabPFN on the early externally-validated data, evaluated row-level (leaky) — the minority HT class collapsed.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve or feature importance).
+- **Evaluation split:** subject-dependent — random **row-level** split (`--external`), with confirmed
+  leakage: the log warns of 115 mice shared between train/test (and 115 train/val, 115 val/test). The
+  same mouse appears across sets, so this is the optimistic setting.
+- **Dataset:** early external set `outputs/aggregated_external/all_data_external.csv` — predates the
+  official Issue #46 baseline (no HET→WT correction / current filters). Test = 2,617 recordings
+  (HT 25.0% / WT 75.0%); train 7,848 rows, val 2,616 rows.
+- **Label convention here is flipped:** in this run **class 0 = HT** (minority) and **class 1 = WT** —
+  the opposite of the current pipeline. Metrics below are mapped back to WT/HT.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.773 | 0.594 | — |
+| Recall | 0.966 | 0.150 | — |
+| F1 | 0.859 | 0.239 | weighted **0.704** |
+| Accuracy | | | **0.762** (train 0.778) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1896, WT→HT 67], [HT→WT 556, HT→HT 98]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.762 | 0.733 | +0.029 |
+| Weighted F1 | 0.704 | 0.749 | −0.045 |
+| WT F1 | 0.859 | 0.785 | +0.074 |
+| HT F1 | 0.239 | 0.649 | −0.410 |
+| HT recall | 0.150 | 0.940 | −0.790 |
+| HT precision | 0.594 | 0.496 | +0.098 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- **The minority HT class collapsed:** HT recall is just **0.150** (−0.790 vs base) — the model finds
+  fewer than 1 in 6 ASD-model pups, calling WT for almost everyone (WT recall 0.966). HT F1 drops to
+  0.239, the opposite failure mode from the high-recall base XGBoost.
+- The headline accuracy of 0.762 is **misleading** — it is mostly the 75% WT majority being labelled WT.
+  Weighted F1 (0.704) is below the base model (−0.045) and the macro F1 is only ~0.55, exposing the
+  collapse the accuracy hides.
+- HT precision (0.594) is the one bright spot — the few HT calls are cleaner than the base model
+  (+0.098) — but recall is far too low to be useful for screening.
+- Despite the row-level leakage that should help (shared mice across train/test), TabPFN still does not
+  learn the minority class on this pre-baseline external data; train 0.778 vs test 0.762 shows little
+  overfitting, just weak HT signal.
+
+## Recommendations
+- Do not use this run. It predates the Issue #46 baseline filters and HET→WT correction and the HT class
+  has collapsed; use the superseding `results/tabular_models/tabpfn_subject_eval_dependent_baseline`.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `logs/out.txt` — flags, data source, split info, leakage warning, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/tabpfn_subject_eval_independent/README.md
+++ b/results/legacy/tabular_models/tabpfn_subject_eval_independent/README.md
@@ -1,0 +1,60 @@
+# tabpfn_subject_eval_independent — TabPFN · subject-independent
+
+**Status:** archived — superseded by `results/tabular_models/tabpfn_subject_eval_independent_baseline`.
+
+> Legacy TabPFN on the pre-baseline data, evaluated **leak-free** (split grouped by mouse) — collapses to near-chance.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve or feature importance).
+- **Evaluation split:** subject-independent — group-aware split **by mouse** (`--group-split`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** legacy `outputs/aggregated/all_data.csv` — predates the Issue #46 filters and the
+  April-2026 HET→WT label correction. Test = 1,466 rows from 18 held-out mice (WT 72.0% / HT 28.0%);
+  train 6,000 / val 2,049.
+- **Label note:** this legacy run encodes class 0 = HT (minority, 28.0%) and class 1 = WT (majority);
+  numbers below are remapped to the standard WT/HT naming used by the base model.
+- **What was adapted vs the base model:** two levers change together — model family (TabPFN instead of
+  XGBoost) **and** evaluation moves from subject-dependent to subject-independent, on the older dataset.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.744 | 0.308 | — |
+| Recall | 0.544 | 0.521 | — |
+| F1 | 0.629 | 0.387 | weighted **0.561** |
+| Accuracy | | | **0.538** (train 0.862) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 574, WT→HT 481], [HT→WT 197, HT→HT 214]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.538 | 0.733 | −0.195 |
+| Weighted F1 | 0.561 | 0.749 | −0.188 |
+| WT F1 | 0.629 | 0.785 | −0.156 |
+| HT F1 | 0.387 | 0.649 | −0.262 |
+| HT recall | 0.521 | 0.940 | −0.419 |
+| HT precision | 0.308 | 0.496 | −0.188 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- This legacy leak-free run is **near chance**: accuracy 0.538 and weighted F1 0.561, ~0.19 below the
+  dependent base model on every overall metric. The combination of the older un-filtered data and the
+  honest group split breaks generalization to unseen mice.
+- The minority class fails badly — **HT F1 0.387** (precision 0.308, recall 0.521): roughly two-thirds of
+  HT predictions are false positives and nearly half of true HT pups are missed.
+- WT is no longer carried: WT recall drops to 0.544 (574/1055 correct), so the model is closer to a coin
+  flip than to a usable WT-vs-HT separator.
+- Train 0.862 vs test 0.538 (0.32 gap) shows the model fits the training mice but does not transfer;
+  TabPFN merges val into train, which inflates the train figure.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `logs/out.txt` — flags, split info, class balance, classification report, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/tabpfn_subject_eval_independent_external/README.md
+++ b/results/legacy/tabular_models/tabpfn_subject_eval_independent_external/README.md
@@ -1,0 +1,67 @@
+# tabpfn_subject_eval_independent_external — TabPFN · subject-independent · external dataset
+
+**Status:** archived — superseded by `results/tabular_models/tabpfn_subject_eval_independent_baseline`.
+
+> TabPFN on the older externally-validated dataset, evaluated **leak-free** (split grouped by mouse) — the minority class collapses.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; no feature-importance or
+  learning curve; the validation set is merged into train).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--group-split`), so no
+  mouse appears in two sets. Honest "generalize to unseen mice" setting, harder than the dependent base
+  model (which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** older `--external` cohort (`outputs/aggregated_external/all_data_external.csv`), predating
+  the official Issue #46 baseline filters and the April-2026 HET→WT correction.
+  Train 7,706 / Val 3,018 / Test 2,357 rows; Test = 2,357 recordings from 23 held-out mice
+  (WT 79.8% / HT 20.2%).
+- **Label note:** this legacy run encodes class 0 = HT and class 1 = WT (the opposite of the current
+  pipeline); the numbers below are reported by class name, not by index.
+- **What was adapted vs the base model:** model family (TabPFN instead of XGBoost), evaluation moves
+  from subject-dependent to subject-independent, **and** the data is the older external cohort.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.788 | 0.163 | — |
+| Recall | 0.778 | 0.171 | — |
+| F1 | 0.783 | 0.166 | weighted **0.659** |
+| Accuracy | | | **0.656** (train 0.831) |
+
+Confusion matrix (rows = true, cols = pred): `[[HT→HT 81, HT→WT 394], [WT→HT 417, WT→WT 1465]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.656 | 0.733 | −0.077 |
+| Weighted F1 | 0.659 | 0.749 | −0.090 |
+| WT F1 | 0.783 | 0.785 | −0.002 |
+| HT F1 | 0.166 | 0.649 | −0.483 |
+| HT recall | 0.171 | 0.940 | −0.769 |
+| HT precision | 0.163 | 0.496 | −0.333 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The minority class **collapses**: HT recall 0.171 and HT F1 0.166 mean the model misses ~5 of every 6
+  ASD-model pups. It predicts WT for almost everyone (only 498 of 2,357 test rows called HT, 81 of them
+  correct), so overall accuracy 0.656 is carried almost entirely by the 79.8% WT majority.
+- HT precision 0.163 is even below the 20.2% HT prevalence — HT calls are no better than random (a
+  blind guess at the base rate would score ~0.202), the worst tabular run on this anchor (HT F1 −0.483
+  vs base).
+- WT performance is intact (F1 0.783, −0.002 vs base), which is what props up the weighted score and
+  masks the failure on the class that matters.
+- The leak-free split plus the older external cohort (no Issue #46 filters, no HET→WT correction)
+  compound: the same TabPFN on the corrected `--baseline` data reaches HT F1 0.610 — this external run
+  is why it was superseded.
+
+## Recommendations
+- Do not use this run for any new-mouse estimate; prefer the superseding
+  `results/tabular_models/tabpfn_subject_eval_independent_baseline`, which fixes the minority collapse.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `logs/out.txt` — flags, split info, class balance, classification report, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_2015_2022/README.md
+++ b/results/legacy/tabular_models/xgboost_2015_2022/README.md
@@ -1,0 +1,57 @@
+# xgboost_2015_2022 — XGBoost · subject-dependent · strain2 (2015/2018)
+
+**Status:** archived — superseded by `results/tabular_models/strain/xgboost_strain2_subject_eval_dependent_baseline`.
+
+> Early XGBoost run on the 2015/2018-only cohort (pure BALB/c), before the strain2 baseline pipeline.
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe — no 200-trial search, the old default hyperparameters.
+- **Cohort:** strain2 predecessor — only the 2015/2018 years (pure BALB/c classic published cohort),
+  not the mixed strain1 background. This run predates the Issue #46 baseline filters and the
+  April-2026 HET→WT correction, so its data slice differs from the current strain2 baseline.
+- **Evaluation split:** subject-dependent — rows split randomly, so a mouse can appear in both train
+  and test (leakage; optimistic vs a leak-free split). Same setting as the base model.
+- **Label encoding (legacy quirk):** this run encodes class `1.0` = WT (majority, support 992) and
+  class `0.0` = HT (minority, support 473); the minority fraction here is ~32%, higher than the
+  ~24% baseline. Metrics below are restated in WT/HT terms.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.94 | 0.58 | — |
+| Recall | 0.69 | 0.92 | — |
+| F1 | 0.80 | 0.71 | weighted **0.77** |
+| Accuracy | | | **0.760** (train 0.798) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 681, WT→HT 311], [HT→WT 40, HT→HT 433]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.760 | 0.733 | +0.027 |
+| Weighted F1 | 0.770 | 0.749 | +0.021 |
+| WT F1 | 0.800 | 0.785 | +0.015 |
+| HT F1 | 0.710 | 0.649 | +0.061 |
+| HT recall | 0.920 | 0.940 | −0.020 |
+| HT precision | 0.580 | 0.496 | +0.084 |
+
+## Key insights
+- Numbers beat the base model across the board (accuracy +0.027, weighted F1 +0.021, HT F1 +0.061),
+  but the comparison is not apples-to-apples: this is a narrower, easier slice — only the 2015/2018
+  pure-BALB/c cohort, with a ~32% HT minority and pre-baseline filtering.
+- The minority class is the strong point here: **HT precision 0.58 (+0.084 vs base)** with HT recall
+  still high at 0.92, so HT F1 0.71 — the cleaner single-strain data separates WT vs HT better than
+  the mixed-background baseline.
+- The subject-dependent split means mice leak across train/test, so the train→test gap is small
+  (0.798 → 0.760) and these figures are optimistic; a leak-free split would land lower.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/confusionmatrix_strain1.png`, `plots/confusionmatrix_strain2.png` — per-subgroup ("new pup" /
+  "old pup") confusion matrices. `plots/AUC_error.png` — AUC/error training curve.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — XGBoost feature importances.
+- `model/XGBmodel.pkl` — fitted XGBoost model. `logs/out.txt` — accuracies, classification report,
+  confusion matrix, feature-importance vector.
+- Metrics source: `logs/out.txt` (classification report; no `comparison_vs_baseline.txt` in this folder).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_subject_eval_dependent/README.md
+++ b/results/legacy/tabular_models/xgboost_subject_eval_dependent/README.md
@@ -1,12 +1,72 @@
-# Results — Pipeline Data, Subject-Dependent Evaluation
+# xgboost_subject_eval_dependent — XGBoost · subject-dependent
 
-**Data source:** `outputs/aggregated/all_data.csv` (9,515 rows, 87 mice)
-**Evaluation:** Subject-dependent — random row-level split (subject overlap between train/test)
-**Flags:** none (baseline)
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
 
-```bash
-python3 src/classification/tabular/train_classifier.py
-```
+> Legacy untuned XGBoost on the old aggregated dataset, evaluated subject-dependent (rows split randomly, mice leak across sets).
 
-Baseline model using pipeline-processed data with corrected genotype labels.
-Subject-dependent split allows overlap across sets, which inflates accuracy compared to subject-independent evaluation.
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no flags / no hyperparameter search).
+- **Evaluation split:** subject-dependent — random row-level split, so the **same mouse appears in
+  train, val and test** (the log warns: 87 shared mice across every pair). This is the optimistic,
+  leaky setting.
+- **Dataset:** legacy `outputs/aggregated/all_data.csv` — 9,515 rows from 87 mice, **not** the official
+  Issue-#46 baseline (~12,323 recordings) the current base model uses. Test = 1,903 rows
+  (HET 30.9% / WT 69.1%); class balance is more imbalanced here than the baseline ~24% HET.
+- **Label convention (legacy):** class 0 = HET/HT (minority), class 1 = WT — the reverse of the current
+  runs. Numbers below are mapped back to WT / HT.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.974 | 0.480 | — |
+| Recall | 0.531 | 0.968 | — |
+| F1 | 0.687 | 0.641 | weighted **0.673** |
+| Accuracy | | | **0.666** (train 0.706) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 698, WT→HT 617], [HT→WT 19, HT→HT 569]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.666 | 0.733 | −0.067 |
+| Weighted F1 | 0.673 | 0.749 | −0.076 |
+| WT F1 | 0.687 | 0.785 | −0.098 |
+| HT F1 | 0.641 | 0.649 | −0.008 |
+| HT recall | 0.968 | 0.940 | +0.028 |
+| HT precision | 0.480 | 0.496 | −0.016 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Even on the leaky subject-dependent split this legacy run trails the current base model everywhere but
+  the minority class: test accuracy 0.666 (−0.067) and weighted F1 0.673 (−0.076). The gap is the **old
+  dataset and label state**, not the split — both runs are dependent.
+- The model collapses toward HET: **HT recall 0.968** but **WT recall only 0.531**, so it over-calls the
+  ASD-model class and mislabels nearly half of true WT pups (617 of 1,315 WT → HT).
+- **HT precision is 0.480** — about half of HET predictions are false positives; HT F1 0.641 is barely
+  below the base (−0.008) only because recall is inflated by the over-calling.
+- Train 0.706 vs test 0.666 is a small gap, but it is meaningless for generalization here: mouse overlap
+  across train/test means the test set is not truly held out.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance.
+- `model/XGBmodel.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+
+## Original notes
+> **Data source:** `outputs/aggregated/all_data.csv` (9,515 rows, 87 mice)
+> **Evaluation:** Subject-dependent — random row-level split (subject overlap between train/test)
+> **Flags:** none (baseline)
+>
+> ```bash
+> python3 src/classification/tabular/train_classifier.py
+> ```
+>
+> Baseline model using pipeline-processed data with corrected genotype labels.
+> Subject-dependent split allows overlap across sets, which inflates accuracy compared to subject-independent evaluation.
+
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_subject_eval_dependent_baseline/README.md
+++ b/results/legacy/tabular_models/xgboost_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,58 @@
+# xgboost_subject_eval_dependent_baseline — XGBoost · subject-dependent
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned legacy XGBoost on the baseline data, evaluated subject-**dependent** (rows split randomly, mice leak across sets).
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no hyperparameter search; `sample_weight=balanced`,
+  `scale_pos_weight=3.1145` for the ~24% HT minority).
+- **Evaluation split:** subject-dependent — random row-level split, so the same mouse appears in
+  train/val/test (the log warns of 106 shared mice across each pair). This is the optimistic,
+  leakage-prone setting, not honest "unseen mouse" generalization.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), from the external
+  aggregated CSV. Train 7,184 / Val 2,395 / Test 2,395 rows; test WT 73.3% / HT 26.7%.
+- **What was adapted vs the base model:** this is the legacy precursor of the current base run — same
+  model family and same dependent split, but an earlier external CSV and code path.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.994 | 0.481 | — |
+| Recall | 0.612 | 0.989 | — |
+| F1 | 0.758 | 0.648 | weighted **0.728** |
+| Accuracy | | | **0.713** (train 0.709) |
+
+Confusion matrix from the log (rows = true, cols = pred): `[[WT→WT 1075, WT→HT 681], [HT→WT 7, HT→HT 632]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.713 | 0.733 | −0.020 |
+| Weighted F1 | 0.728 | 0.749 | −0.021 |
+| WT F1 | 0.758 | 0.785 | −0.027 |
+| HT F1 | 0.648 | 0.649 | −0.001 |
+| HT recall | 0.989 | 0.940 | +0.049 |
+| HT precision | 0.481 | 0.496 | −0.015 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The model runs **HT-recall-hungry**: HT recall 0.989 (only 7 of 639 HT pups missed) but HT precision
+  0.481, so roughly half of HT calls are false positives. WT recall collapses to 0.612 as the cost.
+- Net effect vs the current base is a near-wash on minority-class quality (**HT F1 −0.001**) but a small
+  loss on overall accuracy (−0.020) and weighted F1 (−0.021), driven by the weaker WT recall.
+- Train 0.709 ≈ test 0.713 — no train/test gap, expected here because the random split leaks mice across
+  sets, so "test" is not held out at the mouse level. Treat these numbers as optimistic.
+- This legacy run lands close to the current base on aggregate metrics but at a more extreme operating
+  point; the current base trades a little HT recall (0.940) for much better WT recall (0.660).
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training/AUC curve; `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_subject_eval_dependent_external/README.md
+++ b/results/legacy/tabular_models/xgboost_subject_eval_dependent_external/README.md
@@ -1,5 +1,51 @@
-# Results — External Data, Subject-Dependent Evaluation
+# xgboost_subject_eval_dependent_external — XGBoost · subject-dependent · external dataset
 
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
+
+> Untuned legacy XGBoost on the early external segmentation export, evaluated subject-**dependent** (rows split randomly, mice leak across train/test).
+
+## Overview
+- **Model:** plain XGBoost (untuned legacy recipe; no hyperparameter search).
+- **Evaluation split:** subject-dependent — random **row-level** split (`Strategy: random (row-level)`), so the same mouse appears in train, val and test (the log warns `mouse overlap -- train/test: 115 shared mice`). This is the optimistic/leaky setting, same family as the dependent base model.
+- **Dataset:** legacy **external** export `outputs/aggregated_external/all_data_external.csv` (13,081 rows, 115 mice), pre-dating the official Issue-#46 baseline filters and the April-2026 HET→WT correction. Active flag: `--external`.
+- **Label convention (note):** in this legacy run the encoding is **inverted** — class 0 = HET/HT (minority), class 1 = WT (majority) — opposite to the base model (WT=0, HT=1). Numbers below are remapped to WT/HT semantics for comparability.
+- Train 7,848 / Val 2,616 / Test 2,617 rows; test class balance HT 25.0% / WT 75.0%.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.983 | 0.459 | — |
+| Recall | 0.620 | 0.968 | — |
+| F1 | 0.760 | 0.623 | weighted **0.726** |
+| Accuracy | | | **0.707** (train 0.731) |
+
+Confusion matrix (rows = true, cols = pred, class order 0=HT then 1=WT): `[[HT→HT 633, HT→WT 21], [WT→HT 746, WT→WT 1217]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.707 | 0.733 | −0.026 |
+| Weighted F1 | 0.726 | 0.749 | −0.023 |
+| WT F1 | 0.760 | 0.785 | −0.025 |
+| HT F1 | 0.623 | 0.649 | −0.026 |
+| HT recall | 0.968 | 0.940 | +0.028 |
+| HT precision | 0.459 | 0.496 | −0.037 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Even on the leaky dependent split, the legacy external run trails the dependent base model on every aggregate metric — accuracy 0.707 (−0.026), weighted F1 0.726 (−0.023) — confirming the unfiltered external export is weaker than the corrected baseline data.
+- The model is biased hard toward the minority: **HT recall 0.968** (catches almost every ASD-model pup) but **HT precision 0.459** (more than half of HT calls are false positives), and it misclassifies 746 of 1,963 WT mice as HT.
+- WT recall collapses to 0.620 as the flip side, so the apparent HT sensitivity comes at a heavy WT cost; HT F1 0.623 is below the base model's 0.649.
+- Train (0.731) and test (0.707) are close, so there is little overfit here — the ceiling is the data/recipe, not variance; the small train-test gap is despite the leaky split.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`, `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — AUC/error training curve. `plots/feature_importance_1.png`, `plots/feature_importances_0.png` — feature importances.
+- `model/XGBmodel.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+
+## Original notes
 **Data source:** `outputs/external/aggregated/all_data_external.csv` (13,081 rows, 115 mice)
 **Evaluation:** Subject-dependent — random row-level split (subject overlap between train/test)
 **Flags:** `--external`
@@ -10,3 +56,6 @@ python3 src/classification/tabular/train_classifier.py --external
 
 Uses the external segmentation file which contains correct individual genotyping
 and 28 additional mice (including 24 from 2024 that were missing from the pipeline due to absent Sex data).
+
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_subject_eval_independent/README.md
+++ b/results/legacy/tabular_models/xgboost_subject_eval_independent/README.md
@@ -1,12 +1,83 @@
-# Results — Pipeline Data, Subject-Independent Evaluation
+# xgboost_subject_eval_independent — XGBoost (untuned legacy) · subject-independent
 
-**Data source:** `outputs/aggregated/all_data.csv` (9,515 rows, 87 mice)
-**Evaluation:** Subject-independent — group split by subject (no subject in more than one set)
-**Flags:** `--group-split` or `--independent`
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_dependent_baseline`.
 
-```bash
-python3 src/classification/tabular/train_classifier.py --group-split
-```
+> Legacy untuned XGBoost on the old pipeline data, evaluated **leak-free** (split grouped by mouse).
 
-Fair evaluation of the pipeline data — prevents data leakage by keeping
-all recordings from a given subject in the same split.
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (no hyperparameter search).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--group-split` /
+  `--independent`), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak across
+  train/test).
+- **Dataset:** legacy `outputs/aggregated/all_data.csv` — predates the official baseline (this run does
+  **not** apply the Issue #46 filters or the April-2026 HET→WT correction). Note the label encoding is
+  inverted vs the current base model: here class 0 = HT (minority, 28.0% of test), class 1 = WT.
+- **Split:** group-aware by `mouse_idx` — train 6,000 rows / 51 mice, val 2,049 / 18, test 1,466 / 18.
+  Test balance WT 72.0% / HT 28.0%.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.820 | 0.370 | — |
+| Recall | 0.539 | 0.696 | — |
+| F1 | 0.651 | 0.484 | weighted **0.604** |
+| Accuracy | | | **0.583** (train 0.824) |
+
+Confusion matrix (rows = true, cols = pred): `[[HT→HT 286, HT→WT 125], [WT→HT 486, WT→WT 569]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.583 | 0.733 | −0.150 |
+| Weighted F1 | 0.604 | 0.749 | −0.145 |
+| WT F1 | 0.651 | 0.785 | −0.134 |
+| HT F1 | 0.484 | 0.649 | −0.165 |
+| HT recall | 0.696 | 0.940 | −0.244 |
+| HT precision | 0.370 | 0.496 | −0.126 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The leak-free split is brutal here: accuracy collapses to **0.583** (−0.150 vs the dependent base) and
+  weighted F1 to **0.604** (−0.145) — the full ~15-pt dependent→independent drop lands on this untuned
+  legacy model with no regularization to absorb it.
+- The minority class is barely separable — **HT precision 0.370** (about 2 in 3 HT calls are false
+  positives) and HT F1 0.484; HT recall 0.696 means it still misses ~30% of ASD-model pups.
+- WT recall also caves to 0.539: the model over-predicts HT (486 true-WT pushed to HT in the confusion
+  matrix), so neither class is reliably called.
+- Train 0.824 vs test 0.583 (0.24 gap) shows heavy overfitting to the training mice — expected for an
+  untuned tree model on a by-mouse split.
+
+## Recommendations
+- Do not use this run for reporting — it is on legacy unfiltered data with no tuning. Use the current
+  baseline tabular runs under `results/tabular_models/` instead.
+- For a leak-free XGBoost estimate, prefer the tuned independent recipe
+  (`results/tabular_models/xgboost_tuned_independent_subject_eval_independent_baseline`, heavily
+  regularized/shallow), which targets exactly this split.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per cohort).
+- `plots/AUC_error.png` — training/AUC curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature-importance plots.
+- `model/XGBmodel.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+
+## Original notes
+*Preserved from the original hand-written README before auto-summarization.*
+
+> # Results — Pipeline Data, Subject-Independent Evaluation
+>
+> **Data source:** `outputs/aggregated/all_data.csv` (9,515 rows, 87 mice)
+> **Evaluation:** Subject-independent — group split by subject (no subject in more than one set)
+> **Flags:** `--group-split` or `--independent`
+>
+> ```bash
+> python3 src/classification/tabular/train_classifier.py --group-split
+> ```
+>
+> Fair evaluation of the pipeline data — prevents data leakage by keeping
+> all recordings from a given subject in the same split.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_subject_eval_independent_baseline/README.md
+++ b/results/legacy/tabular_models/xgboost_subject_eval_independent_baseline/README.md
@@ -1,0 +1,67 @@
+# xgboost_subject_eval_independent_baseline — XGBoost (untuned legacy) · subject-independent
+
+**Status:** archived — superseded by `results/tabular_models/xgboost_subject_eval_independent_baseline`.
+
+> Untuned legacy XGBoost on the baseline data, evaluated **leak-free** (split grouped by mouse) — collapses toward HT.
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (`sample_weight=balanced`, `scale_pos_weight=2.9344`).
+  No hyperparameter search — the tuned variants live in separate folders.
+- **Evaluation split:** subject-independent — group-aware train/val/test split **by `mouse_idx`**
+  (`--independent`), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak across
+  train/test).
+- **Dataset:** official baseline (`all_data_external_baseline.csv`; Issue #46 filters; April-2026
+  HET→WT correction). Train 6,893 rows / 63 mice, val 2,595 / 21 mice, test 2,486 / 22 mice.
+  Test = WT 70.1% / HT 29.9%.
+- **What was adapted vs the base model:** evaluation moves from subject-dependent to
+  subject-independent; the model family (XGBoost) is unchanged from the base.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.977 | 0.417 | — |
+| Recall | 0.417 | 0.977 | — |
+| F1 | 0.584 | 0.584 | weighted **0.584** |
+| Accuracy | | | **0.584** (train 0.790) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 726, WT→HT 1017], [HT→WT 17, HT→HT 726]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.584 | 0.733 | −0.149 |
+| Weighted F1 | 0.584 | 0.749 | −0.165 |
+| WT F1 | 0.584 | 0.785 | −0.201 |
+| HT F1 | 0.584 | 0.649 | −0.065 |
+| HT recall | 0.977 | 0.940 | +0.037 |
+| HT precision | 0.417 | 0.496 | −0.079 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- **Degenerate collapse toward HT:** the model predicts HT for almost everyone — HT recall 0.977 but
+  WT recall only 0.417 (it mislabels 1,017 of 1,743 WT recordings as HT). Accuracy 0.584 sits barely
+  above the WT base rate the model abandons.
+- Moving dependent → independent costs the full honest gap here: −0.149 accuracy and −0.165 weighted
+  F1 vs the dependent base, far worse than the typical 10–15 pt drop, because the untuned recipe
+  over-weights the minority class on unseen mice.
+- **HT precision ≈ 0.42** — well under half of HT calls are correct; the high HT recall is bought by
+  flooding the positive class, not by genuine separation (HT F1 only 0.584).
+- Train 0.790 vs test 0.584 (0.21 gap) confirms the recipe does not generalize across mice.
+
+## Recommendations
+- Do not use this untuned-on-independent configuration; prefer `xgboost_tuned_independent_baseline`,
+  whose heavily regularized/shallow hyperparameters were searched for exactly this split type.
+- If this recipe must be kept, lower class weighting (the `--independent` collapse is driven by
+  `scale_pos_weight`) and threshold-tune toward a controlled `target_recall` (~0.80).
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training/validation AUC and error curves.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/legacy/tabular_models/xgboost_subject_eval_independent_external/README.md
+++ b/results/legacy/tabular_models/xgboost_subject_eval_independent_external/README.md
@@ -1,11 +1,65 @@
-# Results — External Data, Subject-Independent Evaluation
+# xgboost_subject_eval_independent_external — XGBoost · subject-independent · external dataset
 
-**Data source:** `outputs/external/aggregated/all_data_external.csv` (13,081 rows, 115 mice)
-**Evaluation:** Subject-independent — group split by subject (no subject in more than one set)
-**Flags:** `--external --group-split` (or `--external --independent`)
+**Status:** archived — superseded by the current `--baseline` runs under `results/`.
 
-```bash
-python3 src/classification/tabular/train_classifier.py --external --group-split
-```
+> Untuned legacy XGBoost on the early *external* dataset, evaluated **leak-free** (split grouped by mouse) — the most rigorous legacy setting, and it collapses.
 
-Most rigorous setting: correct genotyping and no leakage across subjects.
+## Overview
+- **Model:** plain XGBoost (untuned legacy recipe; no per-split hyperparameter search).
+- **Evaluation split:** subject-independent — group-aware split **by `mouse_idx`** (`--group-split` / `--independent`), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** legacy **external** corpus (`--external`): `outputs/aggregated_external/all_data_external.csv`, 13,081 rows from 115 mice. Predates the official baseline (Issue #46 filters + April-2026 HET→WT correction), so numbers are not directly comparable to current `--baseline` runs.
+- **Class convention here is inverted vs the base model:** in this run class 0 = HET (the ASD-model positive minority) and class 1 = WT (majority). Test = 2,357 recordings from 23 held-out mice (HT 20.2% / WT 79.8%).
+- **What was adapted vs the base model:** two levers change together — dataset (legacy external vs official baseline) **and** evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.948 | 0.302 | — |
+| Recall | 0.476 | 0.897 | — |
+| F1 | 0.634 | 0.452 | weighted **0.597** |
+| Accuracy | | | **0.561** (train 0.752) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 896, WT→HT 986], [HT→WT 49, HT→HT 426]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.561 | 0.733 | −0.172 |
+| Weighted F1 | 0.597 | 0.749 | −0.152 |
+| WT F1 | 0.634 | 0.785 | −0.151 |
+| HT F1 | 0.452 | 0.649 | −0.197 |
+| HT recall | 0.897 | 0.940 | −0.043 |
+| HT precision | 0.302 | 0.496 | −0.194 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- **Near-collapse onto the minority class:** the model predicts HET for almost everyone (HT recall 0.897, WT recall only 0.476). It mislabels 986 of 1,882 true WT recordings as HET, dragging test accuracy down to 0.561 — well below the 79.8% WT prior.
+- The leak-free external split is brutal here: **−0.172 test accuracy** and **−0.197 HT F1** vs the dependent base model, far past the usual 10–15 pt dependent→independent drop, compounded by the noisier pre-Issue-#46 external data.
+- Class separation is essentially gone — **HT precision 0.302** (≈7 in 10 HET calls are false positives); HT F1 0.452 is mostly recall, not real discrimination.
+- Train 0.752 vs test 0.561 (0.19 gap): even on its own training mice the untuned recipe is weak, so this is under-fitting plus poor generalization, not classic overfitting.
+
+## Recommendations
+- Do not use this run for any operating-point or generalization estimate — it is superseded by the current `--baseline` XGBoost runs (Issue #46 filters + HET→WT correction). Prefer those for the honest "new-mouse" number.
+
+## Artifacts
+- `plots/confusionmatrix.png`, `plots/conf_matrix.png`, `plots/confusionmatrix_strain1.png`, `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training/validation AUC curve. `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importances.
+- `model/XGBmodel.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+
+## Original notes
+> # Results — External Data, Subject-Independent Evaluation
+>
+> **Data source:** `outputs/external/aggregated/all_data_external.csv` (13,081 rows, 115 mice)
+> **Evaluation:** Subject-independent — group split by subject (no subject in more than one set)
+> **Flags:** `--external --group-split` (or `--external --independent`)
+>
+> ```bash
+> python3 src/classification/tabular/train_classifier.py --external --group-split
+> ```
+>
+> Most rigorous setting: correct genotyping and no leakage across subjects.
+
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/bilstm_subject_eval_dependent_baseline/README.md
+++ b/results/neural_networks/bilstm_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,62 @@
+# bilstm_subject_eval_dependent_baseline — BiLSTM · subject-dependent
+
+> BiLSTM on the official baseline data, evaluated subject-**dependent** (random session split) — collapses to predicting HT for everyone.
+
+## Overview
+- **Model:** BiLSTM (~149K params) over chronological per-syllable sequences (order preserved), unlike
+  the tabular base model's 48 aggregated per-recording features. Scored at the **session** level.
+- **Evaluation split:** subject-dependent — random **session-level** split, so the same mouse can sit in
+  train, val and test (the log confirms train/test overlap of 61 shared mice). This is the leaky,
+  optimistic setting, the same family as the dependent base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Split 244 train / 82 val / 82 test sessions; test is HT 23% / WT 77%.
+- **Training:** `pos_weight=3.207`, lr 1e-3 with decay, early-stopped at epoch 16 (best val AUC 0.778).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.000 | 0.232 | — |
+| Recall | 0.000 | 1.000 | — |
+| F1 | 0.000 | 0.376 | weighted **0.087** |
+| Accuracy | | | **0.232** (train 0.242) |
+
+Test AUC-ROC 0.790 (best val AUC 0.778). The model predicts **HT for every test session** — WT recall
+0.0, HT recall 1.0 — so accuracy collapses to the HT prevalence (0.232).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.232 | 0.733 | −0.501 |
+| Weighted F1 | 0.087 | 0.749 | −0.662 |
+| WT F1 | 0.000 | 0.785 | −0.785 |
+| HT F1 | 0.376 | 0.649 | −0.273 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.232 | 0.496 | −0.264 |
+
+*Caveat: NN are scored on session-level sequence data (82 test sessions here) vs the tabular base's
+recording-level data (~2,465 rows), so this comparison is directional, not like-for-like.*
+
+## Key insights
+- **Degenerate collapse.** The argmax classifier labels every test session HT (HT recall 1.0, WT recall
+  and WT F1 both 0.0); accuracy 0.232 just equals the HT base rate. The model learned nothing usable at
+  the default 0.5 cut.
+- **AUC tells a different story than accuracy.** Test AUC 0.790 means the ranking carries real signal —
+  the collapse is a thresholding/calibration failure, not an absence of separability. With `pos_weight=3.207`
+  the decision boundary is pushed all the way onto the minority class.
+- **Train mirrors test** (train acc 0.242, train AUC 0.807): this is not overfitting but a stuck,
+  all-HT operating point on both sets, despite the leaky dependent split that usually flatters scores.
+- Validation accuracy peaked early (0.707 at epoch 5) then drifted down while loss rose — the chosen
+  best-AUC checkpoint sits at a non-discriminative threshold.
+
+## Recommendations
+- Fix the collapse before trusting this config: the **balanced minibatch sampler (D)** is the most
+  reliable remedy; milder class weighting (B `pos_weight_beta=0.5`) or removing it (C `beta0`) and
+  threshold tuning on the 0.790-AUC scores are the cheap next levers.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (all-HT column).
+- `plots/roc_curve.png` — ROC (AUC 0.790). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/bilstm_subject_eval_independent_baseline/README.md
+++ b/results/neural_networks/bilstm_subject_eval_independent_baseline/README.md
@@ -1,0 +1,68 @@
+# bilstm_subject_eval_independent_baseline — BiLSTM · subject-independent
+
+> BiLSTM (~149K params) on the official baseline data, evaluated **leak-free** (split grouped by mouse) — **collapses to predicting HT for almost everyone**.
+
+## Overview
+- **Model:** BiLSTM (~149K params) over a chronological per-syllable sequence (syllable order preserved),
+  unlike the tabular base model's 48 aggregated per-recording features. Scored at **session level**.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Test = 90 sessions from 22 held-out mice (WT 79% / HT 21%).
+- **Training:** `pos_weight=3.250` class weighting; 16/100 epochs (early-stopped on val AUC 0.847);
+  238 train / 80 val / 90 test sessions; `MAX_SEQ_LEN=256` (median seq length 236).
+- **What was adapted vs the base model:** model family (sequence BiLSTM instead of XGBoost) **and**
+  evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 1.000 | 0.279 | — |
+| Recall | 0.310 | 1.000 | — |
+| F1 | 0.473 | 0.437 | weighted **0.465** |
+| Accuracy | | | **0.456** (train 0.622) |
+| AUC | | | **0.749** (best val 0.847) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 22, WT→HT 49], [HT→WT 0, HT→HT 19]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.456 | 0.733 | −0.277 |
+| Weighted F1 | 0.465 | 0.749 | −0.284 |
+| WT F1 | 0.473 | 0.785 | −0.312 |
+| HT F1 | 0.437 | 0.649 | −0.212 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.279 | 0.496 | −0.217 |
+
+*Directional only, not like-for-like: this NN is scored on 90 session-level sequences, whereas the
+tabular base model is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse on the minority class.** HT recall = 1.000 with WT recall = 0.310 — the model
+  predicts HT for 68 of 90 test sessions (49 of 71 WT sessions misclassified as HT). Accuracy 0.456 is
+  worse than a WT-majority guess (~0.79), and HT precision 0.279 ≈ the test HT base rate (21%), i.e. no
+  real separation at the 0.5 cut.
+- **Ranking is intact even though the operating point is broken.** Test AUC 0.749 (val AUC peaked 0.847)
+  shows the model orders sessions usefully, but the decision threshold is far off — a classic
+  weighting/threshold problem (`pos_weight=3.250` over-pushes toward HT), not an inability to learn.
+- **The tiny independent split is the root cause.** Only 238 train / 80 val / 90 test sessions across
+  63 train mice (HT 56) leaves almost no signal to calibrate the head; the loss/val curves are noisy and
+  early-stop fires at epoch 16. Train accuracy 0.622 is itself low, so this is under-fit, not over-fit.
+
+## Recommendations
+- Treat the headline metrics as a **collapsed baseline**: the +0.060 HT-recall "win" is an artifact of
+  predicting HT for nearly everyone, not a usable gain.
+- Mitigate collapse before trusting any session-level NN number — milder/zero class weighting
+  (B `beta=0.5`, C `beta0`), the balanced minibatch sampler (D, the most reliable collapse fix),
+  the small-net regularized config for tiny independent splits (F `regsmall`), or post-hoc threshold
+  tuning given the healthy AUC.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (test AUC 0.749). `plots/training_curves.png` — loss/acc/AUC vs epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/cnn1d_subject_eval_dependent_baseline/README.md
+++ b/results/neural_networks/cnn1d_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,63 @@
+# cnn1d_subject_eval_dependent_baseline — 1D-CNN · subject-dependent
+
+> 1D-CNN on chronological per-syllable sequences, baseline data, evaluated on the **leaky** random session split.
+
+## Overview
+- **Model:** 1D-CNN (86,041 params) over a per-session chronological syllable sequence (order preserved,
+  `MAX_SEQ_LEN=256`), not the 48 aggregated per-recording features the tabular base uses. Trained with
+  class weighting (`pos_weight=3.207`), Adam + LR decay, early-stopped at epoch 22 (best val AUC 0.710).
+- **Evaluation split:** subject-dependent — random **session-level** split, so the same mouse leaks across
+  sets (train/test share 61 mice). This is the optimistic in-sample setting, same split family as the base.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice; HT=97 / WT=311. Train 244 · Val 82 · **Test 82 sessions** (HT 23% / WT 77%).
+- **What was adapted vs the base model:** model family only — 1D-CNN over sequences instead of XGBoost over
+  aggregated features; the dependent split is held constant.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.824 | 0.271 | — |
+| Recall | 0.444 | 0.684 | — |
+| F1 | 0.577 | 0.388 | weighted **0.533** |
+| Accuracy | | | **0.500** (train 0.672) |
+
+Test AUC 0.604 (best val AUC 0.710; train AUC 0.843). Support: WT 63, HT 19.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.500 | 0.733 | −0.233 |
+| Weighted F1 | 0.533 | 0.749 | −0.216 |
+| WT F1 | 0.577 | 0.785 | −0.208 |
+| HT F1 | 0.388 | 0.649 | −0.261 |
+| HT recall | 0.684 | 0.940 | −0.256 |
+| HT precision | 0.271 | 0.496 | −0.225 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, while the
+tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- The run is **weak across the board** — test accuracy 0.500 with AUC only 0.604, so the model barely
+  separates the classes even on the leaky in-sample split. It trails the base by 0.20–0.26 on every metric.
+- This is not the classic full collapse (neither class is fully ignored: WT recall 0.444, HT recall 0.684),
+  but the WT side is badly degraded — the model misses **56% of WT** sessions, dragging WT F1 to 0.577.
+- Minority class is poorly resolved: **HT precision 0.271** means ~3 of every 4 HT calls are false
+  positives; HT F1 0.388. Class weighting (`pos_weight=3.207`) tilts the model toward HT without buying
+  real separation.
+- Heavy overfitting: train AUC 0.843 vs test AUC 0.604, and val accuracy never stabilizes
+  (0.44–0.72 across epochs) before early stopping at epoch 22 — symptomatic of only 244 training sessions.
+
+## Recommendations
+- The default 0.5 cut is mis-calibrated here; the sampler/regularization NN variants (D balanced sampler,
+  F regsmall) are the standard fixes for this small-data instability and should be tried before trusting
+  this architecture.
+- Do not use this run as a performance estimate — even on the optimistic dependent split it sits at chance
+  accuracy; the tabular base remains the anchor.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.604). `plots/training_curves.png` — loss/acc/AUC over 22 epochs.
+- `model/cnn1d_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/cnn1d_subject_eval_independent_baseline/README.md
+++ b/results/neural_networks/cnn1d_subject_eval_independent_baseline/README.md
@@ -1,0 +1,68 @@
+# cnn1d_subject_eval_independent_baseline — 1D-CNN · subject-independent
+
+> 1D-CNN over per-syllable sequences on the official baseline data, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** 1D-CNN (~86K params; control/default config, no class-weighting lever beyond the built-in
+  `pos_weight=3.250`). Input is a **chronological per-syllable sequence** (order preserved, `MAX_SEQ_LEN=256`),
+  not the 48 aggregated per-recording features the tabular base uses; scoring is at **session level**.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106 mice.
+  Test = **90 held-out sessions** from 22 mice (WT 79% / HT 21%). Train 238 sessions (63 mice), val 80 (21 mice).
+- **What was adapted vs the base model:** two levers change together — model family (sequence 1D-CNN instead
+  of XGBoost) **and** evaluation moves from subject-dependent to subject-independent.
+- **Training:** early-stopped at epoch 17/100 on val AUC (best val AUC 0.753).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.797 | 0.231 | — |
+| Recall | 0.718 | 0.316 | — |
+| F1 | 0.756 | 0.267 | weighted **0.652** |
+| Accuracy | | | **0.633** (train 0.731) |
+| AUC | | | test **0.609** (best val 0.753) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 51, WT→HT 20], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.633 | 0.733 | −0.100 |
+| Weighted F1 | 0.652 | 0.749 | −0.097 |
+| WT F1 | 0.756 | 0.785 | −0.029 |
+| HT F1 | 0.267 | 0.649 | −0.382 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.231 | 0.496 | −0.265 |
+
+*Comparison is directional, not like-for-like: this NN is scored on **90 session-level sequences**, whereas
+the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **No degenerate collapse, but the minority class fails anyway.** The model predicts both classes (it is
+  not stuck on one label), yet HT performance collapses on its own merits: **HT recall 0.316, HT precision
+  0.231, HT F1 0.267** — it catches only 6 of 19 ASD-model sessions and is wrong on most HT calls.
+- **Class separation is near chance.** Test AUC is **0.609** (vs best val AUC 0.753), so the held-out mice
+  are barely separable; the model defaults toward the WT majority (79% of test), which props up overall
+  accuracy 0.633 while the positive class carries the loss.
+- **Big honest drop vs the dependent base.** HT recall falls −0.624 and HT F1 −0.382 — far beyond the usual
+  10–15 pt dependent→independent penalty. The session-level sequence view plus the tiny leak-free split
+  (only 19 HT test sessions, 56 HT train sessions) gives the CNN very little positive signal to learn from.
+- **Mild train/test gap, large val/test gap.** Train 0.731 vs test 0.633 is modest, but best val AUC 0.753
+  vs test AUC 0.609 shows the val mice were not representative of the test mice — small-N variance dominates.
+
+## Recommendations
+- This control config does not give a usable HT operating point. Compare the class-imbalance levers —
+  especially **D (balanced minibatch sampler)** and **E (focal loss)** — which are the more reliable fixes
+  for minority underperformance on the tiny independent split.
+- Treat the headline number as a **floor** for sequence models on leak-free data, not a deployable classifier;
+  HT precision 0.231 means positive calls are unreliable.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.609). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint (val-AUC selected). `model/scaler.pkl` — feature scaler.
+- `results.json` — full metrics/config. `logs/out.txt` — flags, split info, class balance, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/A_control__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/A_control__bilstm__dependent/README.md
@@ -1,0 +1,66 @@
+# A_control__bilstm__dependent — BiLSTM · subject-dependent · experiment A (control)
+
+> Control-config BiLSTM on the baseline sequences, dependent split — **collapsed**: predicts HT for every test session.
+
+## Overview
+- **Model:** BiLSTM (2 layers, hidden 64, dropout 0.3; ~149K params). Input is a chronological
+  per-syllable sequence (`max_seq_len` 256), scored at the **session level**, unlike the tabular base's
+  48 aggregated per-recording features.
+- **Evaluation split:** subject-dependent — random **session-level** split, so the same mouse appears in
+  train and test (the log confirms train/test share 61 mice). Optimistic/leaky, matching the base model's
+  split type.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311 ≈ 24% positive). Test = 82 sessions (WT 63 / HT 19, 23%).
+- **What was adapted vs the base model:** experiment **A = control** — default NN levers
+  (`pos_weight_beta=1.0`, `sampler=none`, `loss=bce`); the change vs base is the model family
+  (BiLSTM instead of XGBoost) and the sequence/session representation, not the lever.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.000 | 0.232 | — |
+| Recall | 0.000 | 1.000 | — |
+| F1 | 0.000 | 0.376 | weighted **0.087** |
+| Accuracy | | | **0.232** (train 0.242) |
+
+AUC 0.790 · PR-AUC 0.492 · balanced accuracy 0.500 · MCC 0.000. Early-stopped at epoch 16
+(best val AUC 0.778). Confusion matrix (rows = true, cols = pred): `[[WT→WT 0, WT→HT 63], [HT→WT 0, HT→HT 19]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.232 | 0.733 | −0.501 |
+| Weighted F1 | 0.087 | 0.749 | −0.662 |
+| WT F1 | 0.000 | 0.785 | −0.785 |
+| HT F1 | 0.376 | 0.649 | −0.273 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.232 | 0.496 | −0.264 |
+
+*NN are scored on session-level sequence data (~82 test sessions) vs the tabular base's recording-level
+data (~2,465 rows), so this comparison is directional, not like-for-like.*
+
+## Key insights
+- **Degenerate collapse.** The model predicts HT for all 82 test sessions: HT recall 1.000, WT recall
+  0.000, WT F1 0.000, balanced accuracy 0.500, MCC 0.000. Test accuracy (0.232) just equals the HT base
+  rate — there is no real classifier here.
+- **The ranking is not random — only the decision rule is broken.** Test AUC 0.790 (PR-AUC 0.492) shows
+  the probabilities separate the classes reasonably, but the default 0.5 threshold under `pos_weight=3.2`
+  pushes every score above the cut. Collapse is a thresholding/class-weight artifact, not a feature
+  problem.
+- **Train mirrors test** (train acc 0.242 ≈ test 0.232): the collapse is present on training data too, so
+  it is not overfitting — the run never learned a usable WT decision boundary. Val accuracy oscillated
+  (0.24→0.71→0.61) while val AUC stayed ~0.68–0.78, the classic signature of an unstable operating point.
+
+## Recommendations
+- This control run is unusable as-is. Use the AUC (0.790) only as a ranking sanity check, never the 0.5
+  predictions. Move the threshold or rebalance: the **D balanced-minibatch sampler** is the most reliable
+  fix for this collapse; **B (`beta=0.5`)** / **C (`beta=0`)** dial back the class weighting that drove
+  every score over the cut.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — all-HT confusion (normalized + counts).
+- `plots/roc_curve.png` — ROC (AUC 0.790). `plots/training_curves.png` — loss/acc/AUC over 16 epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/A_control__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/A_control__bilstm__independent/README.md
@@ -1,0 +1,69 @@
+# A_control__bilstm__independent — BiLSTM · subject-independent · control experiment
+
+> BiLSTM with default settings on the baseline sequence data, evaluated **leak-free** (split by mouse) — collapses to predicting HT for almost everyone.
+
+## Overview
+- **Model:** BiLSTM (~149K params; 2 layers, hidden 64, dropout 0.3). Input is the chronological
+  per-syllable sequence (order preserved, max 256 syllables/session), not the 48 aggregated tabular
+  features. Scored at **session level**, not recording level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting
+  (harder than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Test = 90 held-out sessions from 22 mice (WT 79% / HT 21%);
+  train 238, val 80.
+- **What was adapted vs the base model:** this is the **A control** config — defaults, no special
+  levers (`pos_weight_beta=1.0` → pos_weight 3.25, sampler none, BCE loss). Plus two structural changes
+  vs base: model family (BiLSTM instead of XGBoost) **and** evaluation moves dependent → independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 1.000 | 0.279 | — |
+| Recall | 0.310 | 1.000 | — |
+| F1 | 0.473 | 0.437 | weighted **0.465** |
+| Accuracy | | | **0.456** (train 0.622) |
+
+AUC-ROC 0.749 · PR-AUC 0.347 · balanced acc 0.655 · MCC 0.294 · best val AUC 0.847 · early-stopped at
+epoch 16/100. Confusion matrix (rows = true, cols = pred): WT recall 0.310 on 71 WT sessions and HT
+recall 1.000 on 19 HT sessions.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.456 | 0.733 | −0.277 |
+| Weighted F1 | 0.465 | 0.749 | −0.284 |
+| WT F1 | 0.473 | 0.785 | −0.312 |
+| HT F1 | 0.437 | 0.649 | −0.212 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.279 | 0.496 | −0.217 |
+
+*NN are scored on session-level sequence data (90 test sessions) vs the tabular base's recording-level
+data (~2,465 rows), so the Δ is directional, not like-for-like.*
+
+## Key insights
+- **Degenerate collapse.** The model predicts HT for nearly everyone: **HT recall = 1.000** while
+  **WT recall = 0.310** (precision 1.00 / recall 0.31 on WT). Accuracy (0.456) falls *below* the
+  21% HT prevalence baseline because it sacrifices the 79% WT majority — the default class weighting
+  (pos_weight 3.25) over-pushes toward the minority class.
+- **Ranking is fine, the threshold is not.** AUC-ROC 0.749 and best val AUC 0.847 show the network
+  *can* separate the classes; the failure is the 0.5 operating point, where HT precision is only 0.279
+  (≈3 of every 4 HT calls are false positives). MCC 0.294 confirms weak-but-nonzero signal.
+- **Tiny independent split amplifies instability.** Only 238 train / 90 test sessions across 22 test
+  mice; train accuracy 0.622 vs val acc oscillating 0.56–0.79 indicates the run never settled, and
+  early stopping fired at epoch 16 on val AUC, not on a stable operating point.
+
+## Recommendations
+- This control run is **not deployable** at the default threshold. Compare against the lever variants
+  built to fix exactly this collapse — `D` (balanced minibatch sampler, the most reliable fix),
+  `B`/`C` (milder/no class weighting), and `F` (regsmall for the tiny independent split).
+- Since AUC is healthy but the 0.5 cut collapses, a tuned decision threshold (or `target_recall`) would
+  recover a usable WT/HT trade-off without retraining.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (AUC 0.749). `plots/training_curves.png` — loss/acc/AUC over 16 epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`. `logs/out.txt` — flags, split info, class balance, per-epoch log.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/A_control__cnn1d__dependent/README.md
+++ b/results/neural_networks/experiments/A_control__cnn1d__dependent/README.md
@@ -1,0 +1,70 @@
+# A_control__cnn1d__dependent — 1D-CNN · subject-dependent · A control (defaults)
+
+> 1D-CNN on chronological per-syllable sequences, default config, subject-dependent split — collapses to ~chance (test accuracy 0.500).
+
+## Overview
+- **Model:** 1D-CNN (~86K params; convolutions over the chronological per-syllable sequence, order
+  preserved). Scored at **session level** (82 test sessions), unlike the tabular base which scores
+  per-recording rows.
+- **Evaluation split:** subject-dependent — random **session-level** split (`subject_eval_independent:
+  false`, `group_split: false`). The log warns of heavy mouse overlap (61 of 64 test mice also in train),
+  so this is the leaky, optimistic setting — yet it still underperforms badly here.
+- **Dataset:** official baseline (`--baseline`; Issue #46 filters; April-2026 HET→WT correction).
+  408 sessions from 106 mice (HT 97 / WT 311); split 244 train / 82 val / 82 test, ~24% HT throughout.
+- **What was adapted vs the base model:** lever **A control** — pure defaults (`pos_weight_beta=1.0`,
+  `sampler=none`, `loss=bce`, `dropout=0.3`, no augmentation/CV). This is the reference NN run before any
+  collapse-mitigation lever (B–H). Two things change vs the tabular base: model family (1D-CNN vs XGBoost)
+  and input (per-syllable sequence vs 48 aggregated features).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.824 | 0.271 | — |
+| Recall | 0.444 | 0.684 | — |
+| F1 | 0.577 | 0.388 | weighted **0.533** |
+| Accuracy | | | **0.500** (train 0.672) |
+
+AUC 0.604 · balanced acc 0.564 · MCC 0.110 · PR-AUC 0.328 · best val AUC 0.710 · early-stopped epoch 22.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 28, WT→HT 35], [HT→WT 6, HT→HT 13]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.500 | 0.733 | −0.233 |
+| Weighted F1 | 0.533 | 0.749 | −0.216 |
+| WT F1 | 0.577 | 0.785 | −0.208 |
+| HT F1 | 0.388 | 0.649 | −0.261 |
+| HT recall | 0.684 | 0.940 | −0.256 |
+| HT precision | 0.271 | 0.496 | −0.225 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, while the
+tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Near-chance and degenerate.** Test accuracy 0.500 with the model tagging HT for most sessions —
+  WT recall collapses to 0.444 (35 of 63 WT sessions called HT) while it still misses HT (recall 0.684).
+  This is the classic over-prediction of the minority class driven by `pos_weight=3.207`, and it lands
+  well below the trivial majority-class (all-WT) baseline of ~0.77.
+- **No real signal carried to test.** AUC 0.604 / MCC 0.110 / PR-AUC 0.328 are barely above random,
+  despite this being the *leaky* subject-dependent split (61/64 test mice seen in train) that should be the
+  easiest possible setting.
+- **Train/val/test all weak.** Train accuracy only 0.672 and val AUC plateaus at 0.710 by epoch 7 before
+  early stopping at epoch 22 — the 1D-CNN never fits the sequences well, so this is underfitting plus a
+  bad operating point, not classic overfitting.
+- Every headline metric is 0.20–0.26 below the tabular base; default-config 1D-CNN on raw sequences is not
+  competitive here and motivates the collapse-mitigation levers (D sampler, F regsmall, etc.).
+
+## Recommendations
+- Do not use this run as an NN baseline of record — the default BCE + `pos_weight` recipe collapses.
+  Compare against the balanced-sampler config (`../*__cnn1d__*` D/H runs), which the brief flags as the
+  most reliable collapse fix.
+- If 1D-CNN is pursued, address underfitting first (longer/larger training, milder class weighting per
+  lever B/C) before tuning the decision threshold.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.604). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint (val AUC 0.710). `model/scaler.pkl` — feature scaler.
+- `results.json` — full metrics + config. `logs/out.txt` — flags, split/overlap warning, class balance, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/A_control__cnn1d__independent/README.md
+++ b/results/neural_networks/experiments/A_control__cnn1d__independent/README.md
@@ -1,0 +1,65 @@
+# A_control__cnn1d__independent — 1D-CNN · subject-independent · experiment A (control)
+
+> Default-config 1D-CNN on chronological per-syllable sequences, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** 1D-CNN (86,041 params) over an ordered per-syllable sequence (chronology preserved,
+  `max_seq_len=256`), unlike the tabular base model's 48 aggregated per-recording features. Scored at
+  **session level** (~82–90 test sessions), not at recording level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting
+  (harder than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice → train 238 (63 mice, HT 24%), val 80 (21 mice, HT 28%), test 90 (22 mice, HT 21%).
+- **What was adapted vs the base model:** experiment **A = control** — defaults, no extra lever
+  (`pos_weight_beta=1.0` → pos_weight 3.250, `sampler=none`, `loss=bce`, `dropout=0.3`,
+  `weight_decay=0.0`). Two things change together vs base: model family (1D-CNN instead of XGBoost) **and**
+  evaluation moves from subject-dependent to subject-independent. Early stopping at epoch 17/100
+  (best val AUC 0.753).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.797 | 0.231 | — |
+| Recall | 0.718 | 0.316 | — |
+| F1 | 0.756 | 0.267 | weighted **0.652** |
+| Accuracy | | | **0.633** (train 0.731) |
+
+AUC 0.609 · balanced acc 0.517 · macro-F1 0.511 · MCC 0.031.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 51, WT→HT 20], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.633 | 0.733 | −0.100 |
+| Weighted F1 | 0.652 | 0.749 | −0.097 |
+| WT F1 | 0.756 | 0.785 | −0.029 |
+| HT F1 | 0.267 | 0.649 | −0.382 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.231 | 0.496 | −0.265 |
+
+*Δ is directional, not like-for-like: this NN is scored on 90 session-level sequences while the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- The control 1D-CNN does **not** collapse — both classes get predicted (HT recall 0.316, WT recall
+  0.718) — but it is barely better than chance: **MCC 0.031, balanced acc 0.517, AUC 0.609**. The
+  separation it learned on val (best val AUC 0.753) does not transfer to held-out mice (test AUC 0.609).
+- The minority class is the weak point: **HT F1 0.267** (precision 0.231, recall 0.316). It catches only
+  6 of 19 ASD-model sessions and over half of its HT calls are false positives — far worse than the
+  dependent base's HT recall 0.940 (−0.624).
+- Headline accuracy (0.633) is propped up by the WT majority (79% of test); on the balanced view there
+  is almost no signal. Train 0.731 vs test 0.633 shows mild overfit, but the bigger gap is val→test,
+  i.e. the leak-free split, not memorization.
+
+## Recommendations
+- This control run is the reference for the other A–H levers; it confirms class weighting alone
+  (`pos_weight 3.25`) is insufficient on the tiny independent split. Compare against the D balanced
+  sampler and F regsmall configs, which target exactly this under-performance.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.609). `plots/training_curves.png` — train/val loss & AUC over 17 epochs.
+- `model/cnn1d_best.pt` — best-val checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/A_control__transformer__dependent/README.md
+++ b/results/neural_networks/experiments/A_control__transformer__dependent/README.md
@@ -1,0 +1,63 @@
+# A_control__transformer__dependent — Transformer · subject-dependent · experiment A (control)
+
+> Transformer baseline run on session sequences, evaluated on a **leaky** session-level split (default config, no class-imbalance lever).
+
+## Overview
+- **Model:** Transformer (~73K params; 2 layers, `d_model`/`hidden_size` 64, dropout 0.3). Input is a
+  chronological per-syllable sequence (order preserved, `max_seq_len` 256), scored at session level —
+  not the 48 aggregated per-recording features the tabular base uses.
+- **Evaluation split:** subject-dependent — random **session-level** split (`subject_eval_independent=false`,
+  `group_split=false`). The log confirms heavy leakage: 61 mice shared between train and test, 56 between
+  train and val, so this is the optimistic in-distribution setting (not generalize-to-unseen-mice).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Split 244 train / 82 val / 82 test sessions; test HT 23% / WT 77%.
+- **What was adapted vs the base model:** experiment A = control (defaults). `pos_weight_beta=1.0`
+  (full inverse-frequency weighting, `pos_weight=3.207`), BCE loss, no sampler, no augmentation, no CV —
+  the reference point the B–H levers are measured against. Switches model family (Transformer vs XGBoost)
+  and granularity (session sequences vs recording rows); the split type stays dependent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.872 | 0.371 | — |
+| Recall | 0.651 | 0.684 | — |
+| F1 | 0.745 | 0.481 | weighted **0.684** |
+| Accuracy | | | **0.659** (train 0.684) |
+
+AUC-ROC 0.655 · balanced accuracy 0.668 · MCC 0.286 · PR-AUC 0.350. Early stopping at epoch 31/100
+(best val AUC 0.688). Confusion matrix (rows = true, cols = pred): `[[WT→WT 41, WT→HT 22], [HT→WT 6, HT→HT 13]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.659 | 0.733 | −0.074 |
+| Weighted F1 | 0.684 | 0.749 | −0.065 |
+| WT F1 | 0.745 | 0.785 | −0.040 |
+| HT F1 | 0.481 | 0.649 | −0.168 |
+| HT recall | 0.684 | 0.940 | −0.256 |
+| HT precision | 0.371 | 0.496 | −0.125 |
+
+*Directional only, not like-for-like: this Transformer is scored on 82 session-level sequences, while the
+tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **No degenerate collapse** — both classes are predicted (HT recall 0.684, WT recall 0.651), so the full
+  `pos_weight=3.207` weighting kept the control run off the all-one-class trap that hits other NN configs.
+- It trails the tabular base on every metric, worst on the minority class: **HT F1 0.481 (−0.168), HT recall
+  0.684 (−0.256), HT precision 0.371 (−0.125)** — barely above the 23% prior, so most HT calls are wrong.
+- Weak separation overall: AUC-ROC 0.655, MCC 0.286, balanced accuracy 0.668 — only modestly above chance,
+  and the small dependent split (82 sessions) makes these numbers high-variance.
+- Train accuracy 0.684 ≈ test 0.659: the model is not overfitting, it is **underfitting** the sequence task —
+  even with leakage it cannot match the aggregated-feature tabular recipe.
+
+## Recommendations
+- Use this control run only as the A reference point for the B–H levers; for any reported "dependent NN"
+  number prefer a config that lifts HT separation, and benchmark new-mouse performance on an independent split.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — normalized + count confusion matrices.
+- `plots/roc_curve.png` — test ROC (AUC 0.655). `plots/training_curves.png` — loss/acc/AUC over 31 epochs.
+- `model/transformer_best.pt` — best checkpoint (val AUC 0.688). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split/data stats and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/A_control__transformer__independent/README.md
+++ b/results/neural_networks/experiments/A_control__transformer__independent/README.md
@@ -1,0 +1,64 @@
+# A_control__transformer__independent — Transformer · subject-independent · experiment A (control)
+
+> Sequence Transformer (defaults, no class-imbalance lever) on baseline data, evaluated **leak-free** (split by mouse).
+
+## Overview
+- **Model:** Transformer (~73K params) over a chronological per-syllable sequence (order preserved),
+  scored at the **session** level — unlike the tabular base model's 48 aggregated per-recording features.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  group-aware), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting
+  (harder than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106 mice;
+  Train 238 sessions (63 mice, HT 24%), Val 80 (21 mice), Test 90 sessions from 22 held-out mice (WT 79% / HT 21%).
+- **What was adapted vs the base model:** experiment **A = control** — defaults only (`pos_weight_beta=1.0`,
+  `sampler=none`, `loss=bce`, dropout 0.3, d_model 64, 2 layers). This is the reference config the
+  B–H levers are tuned against. Two things change at once vs base: model family (Transformer instead of
+  XGBoost) **and** evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.895 | 0.288 | — |
+| Recall | 0.479 | 0.789 | — |
+| F1 | 0.624 | 0.423 | weighted **0.581** |
+| Accuracy | | | **0.544** (train 0.605) |
+
+AUC-ROC 0.675 · PR-AUC 0.474 · balanced acc 0.634 · MCC 0.222 · macro-F1 0.523. Best val AUC 0.810 at
+early stop (epoch 29/100).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.544 | 0.733 | −0.189 |
+| Weighted F1 | 0.581 | 0.749 | −0.168 |
+| WT F1 | 0.624 | 0.785 | −0.161 |
+| HT F1 | 0.423 | 0.649 | −0.226 |
+| HT recall | 0.789 | 0.940 | −0.151 |
+| HT precision | 0.288 | 0.496 | −0.208 |
+
+*Directional only: this NN is scored on 90 session-level sequences vs the tabular base's ~2,465
+recording-level rows, so the comparison is not like-for-like.*
+
+## Key insights
+- The control Transformer is **well below the base model on every metric** — test accuracy 0.544 (−0.189)
+  and weighted F1 0.581 (−0.168). The leak-free split plus no imbalance lever is costly.
+- **Not a degenerate collapse, but skewed minority-biased:** with the default `pos_weight≈3.25` the model
+  over-predicts HT — HT recall 0.789 / WT recall only 0.479, so it misclassifies more than half of WT
+  sessions. HT precision is just 0.288 (≈ 1 in 4 HT calls correct), dragging HT F1 to 0.423.
+- **Train/val/test disagree sharply:** best val AUC 0.810 but test AUC only 0.675, and train accuracy 0.605.
+  On 90 test sessions (19 HT) the held-out mice generalize poorly — typical of the tiny independent split.
+- Useful as the **A baseline**: it shows the imbalance handling needs work (over-shoots HT), motivating the
+  B–H levers (milder/no class weighting, balanced sampler, focal loss, regularization).
+
+## Recommendations
+- Compare against the imbalance-lever experiments — especially **D (balanced sampler)** and **C/B (no/milder
+  class weighting)** — which target exactly this minority over-prediction; D is usually the most reliable fix.
+- For the tiny independent split, also try **F (regsmall)** to reduce the val→test AUC gap (0.810 → 0.675).
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.675). `plots/training_curves.png` — loss/acc/AUC over 29 epochs.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/B_beta0.5__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/B_beta0.5__bilstm__dependent/README.md
@@ -1,0 +1,70 @@
+# B_beta0.5__bilstm__dependent — BiLSTM · subject-dependent · experiment B (beta0.5)
+
+> BiLSTM on baseline sequences with milder class weighting (`pos_weight_beta=0.5`) — collapses to all-WT.
+
+## Overview
+- **Model:** BiLSTM (~149K params; 2 layers, hidden 64). Input is a chronological per-syllable
+  sequence (order preserved, `max_seq_len=256`), not the tabular 48 aggregated per-recording features.
+- **Evaluation split:** subject-dependent — random **session-level** split (`subject_eval_independent=false`,
+  `group_split=false`), so the same mouse can appear in train and test. The log flags this leakage:
+  `train/test: 61 shared mice`. Optimistic setting, same family as the base model.
+- **What was adapted vs base (experiment B):** milder class weighting — `pos_weight_beta=0.5` gives
+  `pos_weight=1.791` instead of the full inverse-frequency weight used by control (A). No sampler, plain
+  BCE loss, no augmentation.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice; scored at **session level**: 244 train / 82 val / 82 test sessions (test HT 23% / WT 77%).
+- **Training:** early-stopped at epoch 16 (best val AUC 0.690); LR decayed 1e-3 → 2.5e-4.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.768 | 0.000 | — |
+| Recall | 1.000 | 0.000 | — |
+| F1 | 0.869 | 0.000 | weighted **0.668** |
+| Accuracy | | | **0.768** (train 0.762) |
+
+Test AUC 0.665 · PR-AUC 0.501 · balanced accuracy **0.500** · MCC **0.000** · macro-F1 0.434.
+
+**Degenerate collapse: the model predicts WT for all 82 test sessions** — HT recall 0.0, HT F1 0.0, so
+"accuracy 0.768" is just the WT base rate (63/82), not real skill.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.768 | 0.733 | +0.035 |
+| Weighted F1 | 0.668 | 0.749 | −0.081 |
+| WT F1 | 0.869 | 0.785 | +0.084 |
+| HT F1 | 0.000 | 0.649 | −0.649 |
+| HT recall | 0.000 | 0.940 | −0.940 |
+| HT precision | 0.000 | 0.496 | −0.496 |
+
+*Comparison is directional, not like-for-like: this NN is scored on session-level sequence data
+(82 test sessions) while the tabular base is scored on recording-level data (~2,465 rows).*
+
+## Key insights
+- **The run is a degenerate collapse to the majority class** — every test session is called WT
+  (HT recall 0.0, HT F1 0.0). The headline accuracy 0.768 only matches the WT prevalence; balanced
+  accuracy 0.500 and MCC 0.000 confirm zero discriminative skill at the 0.5 cut.
+- **Milder weighting (beta=0.5) was too weak to break the collapse.** `pos_weight=1.791` did not push
+  the model off the all-WT optimum; train accuracy (0.762) tracks the same base rate, and val accuracy
+  never moved past ~0.78 across all 16 epochs.
+- **There is some latent signal that the threshold throws away:** test AUC 0.665 / best val AUC 0.690
+  sit above chance, so the ranking is not random — but the operating point is useless, the opposite
+  failure mode to the base model (HT recall 0.940).
+- The +0.035 accuracy / +0.084 WT-F1 "wins" over base are artifacts of predicting the majority class;
+  the −0.649 HT-F1 and −0.940 HT-recall are the real story.
+
+## Recommendations
+- Stronger minority handling is needed: the balanced minibatch **sampler (config D)** is the most
+  reliable fix for this collapse; focal loss (E) or full inverse-frequency weighting (control A) are
+  next to try before beta0.5.
+- Because AUC > 0.5, a threshold sweep could recover some HT recall from this exact checkpoint, but the
+  default-cut model should not be used as-is.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (collapsed to
+  the WT column). `plots/roc_curve.png` — ROC (AUC 0.665). `plots/training_curves.png` — loss/acc/AUC vs epoch.
+- `model/bilstm_best.pt` — best checkpoint (epoch with val AUC 0.690). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split info, class balance and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/B_beta0.5__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/B_beta0.5__bilstm__independent/README.md
@@ -1,0 +1,66 @@
+# B_beta0.5__bilstm__independent — BiLSTM · subject-independent · experiment B (pos_weight_beta=0.5)
+
+> BiLSTM on baseline sequences, evaluated **leak-free** (split by mouse), with milder class weighting (β=0.5) — and it slides toward predicting WT for almost everyone.
+
+## Overview
+- **Model:** BiLSTM (2 layers, hidden 64, dropout 0.3; 148,953 params). Input is the chronological
+  per-syllable sequence (order preserved, `max_seq_len=256`), scored at **session level** — not the 48
+  aggregated per-recording features the tabular base uses.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  group-aware), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting
+  (harder than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice. Train 238 (63 mice, HT 24%) · Val 80 (21 mice, HT 28%) · Test 90 sessions (22 mice, HT 21%).
+- **What was adapted vs base (experiment B):** `pos_weight_beta=0.5` — a **milder** positive-class
+  weight (effective `pos_weight=1.803` instead of the full ~3.25 inverse-frequency) on top of plain BCE;
+  no sampler, no focal, no weight decay. Trained 24 epochs (early-stopped on val AUC 0.800).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.807 | 0.429 | — |
+| Recall | 0.944 | 0.158 | — |
+| F1 | 0.870 | 0.231 | weighted **0.735** |
+| Accuracy | | | **0.778** (train 0.790) |
+
+Test AUC-ROC 0.623 · PR-AUC 0.305 · balanced acc 0.551 · MCC 0.155 · macro-F1 0.550.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 67, WT→HT 4], [HT→WT 16, HT→HT 3]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.778 | 0.733 | +0.045 |
+| Weighted F1 | 0.735 | 0.749 | −0.014 |
+| WT F1 | 0.870 | 0.785 | +0.085 |
+| HT F1 | 0.231 | 0.649 | −0.418 |
+| HT recall | 0.158 | 0.940 | −0.782 |
+| HT precision | 0.429 | 0.496 | −0.067 |
+
+*Directional only: this NN is scored on ~90 session-level sequences, whereas the tabular base is scored on ~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- **Near-WT collapse.** HT recall drops to **0.158** (HT F1 0.231) — the model catches only 3 of 19
+  ASD-model sessions and defaults to WT for the rest. The headline accuracy 0.778 is almost entirely the
+  79% WT majority being predicted correctly; balanced accuracy 0.551 and MCC 0.155 expose how little real
+  signal there is.
+- **β=0.5 is too weak to fix the imbalance.** Halving the positive weight (effective 1.803) was not
+  enough to keep the minority class alive on this tiny independent split; the conservative cut here is the
+  opposite failure mode from the "predict HT for everyone" collapse.
+- **Train↔test gap is modest** (train 0.790 vs test 0.778), so this is not classic overfitting — the
+  model simply learned a majority-leaning decision rule. Val AUC peaked at 0.800 but **test AUC is only
+  0.623**, a large val→test drop that signals the 22-mouse test set is hard and the operating point did
+  not transfer.
+
+## Recommendations
+- Prefer stronger imbalance handling for this split: the balanced minibatch sampler (experiment D) is the
+  most reliable fix for collapse; β=0 (C) or focal loss (E) are alternatives. β=0.5 alone is insufficient.
+- Do not use this run for any "new-mouse" HT-detection estimate — at the default 0.5 cut it misses ~84%
+  of ASD-model sessions.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.623). `plots/training_curves.png` — loss/acc/AUC over 24 epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split info, class balance and early-stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/B_beta0.5__cnn1d__dependent/README.md
+++ b/results/neural_networks/experiments/B_beta0.5__cnn1d__dependent/README.md
@@ -1,0 +1,64 @@
+# B_beta0.5__cnn1d__dependent — 1D-CNN · subject-dependent · experiment B (beta0.5)
+
+> 1D-CNN over chronological per-syllable sequences, scored at session level; milder class weighting (`pos_weight_beta=0.5`).
+
+## Overview
+- **Model:** 1D-CNN (~86K params) over a chronological per-syllable sequence (`max_seq_len=256`,
+  order preserved), not the 48 aggregated per-recording features the tabular base uses.
+- **Evaluation split:** subject-dependent — random **session-level** split, so the same mouse leaks
+  across sets (log: train/test share 61 mice, train/val 56). Optimistic by construction.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Scored at **session level**: train 244 / val 82 / test 82 sessions
+  (test HT 23% / WT 77%).
+- **What was adapted vs the base model:** experiment **B** — milder class weighting
+  (`pos_weight_beta=0.5` → `pos_weight=1.791`), default BCE loss, no sampler, dropout 0.3. Two levers
+  move together vs base: model family (1D-CNN instead of XGBoost) and sequence vs aggregated input.
+  Early-stopped at epoch 22 (best val AUC 0.719).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.774 | 0.250 | — |
+| Recall | 0.762 | 0.263 | — |
+| F1 | 0.768 | 0.256 | weighted **0.649** |
+| Accuracy | | | **0.646** (train 0.828) |
+
+Test AUC 0.583 · balanced acc 0.513 · macro-F1 0.512 · MCC 0.025 · PR-AUC 0.340 (82 test sessions).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.646 | 0.733 | −0.087 |
+| Weighted F1 | 0.649 | 0.749 | −0.100 |
+| WT F1 | 0.768 | 0.785 | −0.017 |
+| HT F1 | 0.256 | 0.649 | −0.393 |
+| HT recall | 0.263 | 0.940 | −0.677 |
+| HT precision | 0.250 | 0.496 | −0.246 |
+
+*Directional only: this NN is scored on 82 session-level sequences, while the tabular base is scored on
+~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- The 1D-CNN is **worse than the base model on every axis** and barely above chance: AUC 0.583, MCC
+  0.025, balanced acc 0.513 — it has almost no real WT/HT separation despite the leaky dependent split.
+- The minority class essentially fails: **HT precision 0.250 / recall 0.263 / F1 0.256** (5 of 19 HT
+  sessions caught). This is not degenerate collapse — milder weighting (beta 0.5) keeps it from
+  predicting one class for everyone — but the model lands close to random on HT.
+- Train 0.828 vs test 0.646 with val AUC drifting down after epoch 7 (peak 0.719) signals overfitting,
+  not capacity: the network memorizes train sessions but the val/test signal stays flat near chance.
+- The accuracy (0.646) is mostly carried by the 77% WT majority; weighted F1 (0.649) confirms the
+  headline number is a majority-class artifact, not genuine skill.
+
+## Recommendations
+- Prefer the balanced-sampler config (experiment **D**), the most reliable fix for the weak/collapsing
+  minority class on this data; beta-only weighting (this run) does not give the CNN usable HT signal.
+- Do not read these numbers as generalization — the split is subject-dependent (mice leak). Use a
+  subject-independent run for any honest "new-mouse" estimate.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png`, `plots/training_curves.png` — test ROC and train/val loss-acc-AUC curves.
+- `model/cnn1d_best.pt` — best checkpoint (epoch 22). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/B_beta0.5__cnn1d__independent/README.md
+++ b/results/neural_networks/experiments/B_beta0.5__cnn1d__independent/README.md
@@ -1,0 +1,66 @@
+# B_beta0.5__cnn1d__independent — 1D-CNN · subject-independent · experiment B (beta0.5)
+
+> 1D-CNN over per-syllable sequences, evaluated **leak-free** (split by mouse), with milder class weighting (`pos_weight_beta=0.5`).
+
+## Overview
+- **Model:** 1D-CNN (~86K params; convolutions over a chronological per-syllable sequence, order
+  preserved — unlike the tabular base, which uses 48 aggregated per-recording features).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting
+  (harder than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice; test = **90 held-out sessions** from 22 mice (WT 79% / HT 21%).
+- **What was adapted vs the base model:** experiment **B — `pos_weight_beta=0.5`** (milder class
+  weighting; effective `pos_weight=1.803` instead of the full inverse-frequency value). Two other levers
+  move together: model family (1D-CNN instead of XGBoost) **and** dependent → subject-independent
+  evaluation. No sampler, plain BCE, dropout 0.3, lr 1e-3; early-stopped at epoch 22 (best val AUC 0.748).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.800 | 0.240 | — |
+| Recall | 0.732 | 0.316 | — |
+| F1 | 0.765 | 0.273 | weighted **0.661** |
+| Accuracy | | | **0.644** (train 0.790) |
+
+AUC 0.532 · balanced accuracy 0.524 · MCC 0.044 · PR-AUC 0.366.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 52, WT→HT 19], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.644 | 0.733 | −0.089 |
+| Weighted F1 | 0.661 | 0.749 | −0.088 |
+| WT F1 | 0.765 | 0.785 | −0.020 |
+| HT F1 | 0.273 | 0.649 | −0.376 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.240 | 0.496 | −0.256 |
+
+*Comparison is directional, not like-for-like: this NN is scored on **session-level sequences** (90 test
+sessions) while the tabular base is scored on **recording-level rows** (~2,465 rows).*
+
+## Key insights
+- **Test AUC 0.532 / MCC 0.044** — the model is barely above chance at separating the classes on unseen
+  mice. The best-val AUC (0.748) does not transfer to test, a clear generalization gap on the tiny
+  independent split (238 train sessions, 63 mice).
+- The minority class collapses on every metric: **HT recall 0.316, HT precision 0.240, HT F1 0.273**.
+  Only 6 of 19 HT sessions are caught, and most HT calls are wrong — the milder `beta=0.5` weighting did
+  not produce a usable positive operating point.
+- This is the opposite tilt from the usual "predict-HT-for-everyone" collapse: here the model defaults
+  toward WT (WT recall 0.732, HT recall 0.316), so the headline accuracy (0.644) is mostly the majority
+  class and the balanced accuracy (0.524) exposes it.
+- Train 0.790 vs test 0.644 plus val AUC drifting down from epoch 7 (0.748) onward signal overfitting on
+  the small leak-free split well before early stopping fired at epoch 22.
+
+## Recommendations
+- This config is not deployable — HT detection (recall 0.316, precision 0.240) is too weak. The brief's
+  most reliable collapse fix is the **balanced sampler (config D)**; also compare `regsmall` (F) for the
+  tiny independent split before tuning the threshold.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (test AUC 0.532). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint (val AUC 0.748). `model/scaler.pkl` — feature scaler.
+- `results.json` — full metrics + config. `logs/out.txt` — flags, split info, class balance, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/B_beta0.5__transformer__dependent/README.md
+++ b/results/neural_networks/experiments/B_beta0.5__transformer__dependent/README.md
@@ -1,0 +1,66 @@
+# B_beta0.5__transformer__dependent — Transformer · subject-dependent · experiment B (beta0.5)
+
+> Transformer on the baseline sequence data, milder class weighting (`pos_weight_beta=0.5`) — **collapses to predicting WT for everyone**.
+
+## Overview
+- **Model:** Transformer (~73K params; chronological per-syllable sequence input, order preserved,
+  scored at session level — not the tabular 48 aggregated per-recording features).
+- **Evaluation split:** subject-dependent — random **session-level** split, so the same mouse can land
+  in train and test (the log warns `train/test: 61 shared mice`). This is the leaky, optimistic setting,
+  matching the base model.
+- **Dataset:** baseline sequence cache (Issue #46 filters; April-2026 HET→WT correction).
+  408 sessions / 106 mice → train 244 / val 82 / test 82; test is WT 77% / HT 23% (63 WT, 19 HT).
+- **What was adapted vs the base model:** experiment **B** — milder class weighting
+  (`pos_weight_beta=0.5`, giving `pos_weight=1.791`; sampler none, BCE loss). The lever is meant to
+  push the minority HT class up without the over-aggressive weighting that flips a model to all-HT.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.768 | 0.000 | — |
+| Recall | 1.000 | 0.000 | — |
+| F1 | 0.869 | 0.000 | weighted **0.668** |
+| Accuracy | | | **0.768** (train 0.787) |
+
+AUC 0.682 · PR-AUC 0.350 · balanced accuracy **0.500** · MCC **0.000** · macro F1 0.434.
+Early stopping at epoch 30 (best val AUC 0.724).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.768 | 0.733 | +0.035 |
+| Weighted F1 | 0.668 | 0.749 | −0.081 |
+| WT F1 | 0.869 | 0.785 | +0.084 |
+| HT F1 | 0.000 | 0.649 | −0.649 |
+| HT recall | 0.000 | 0.940 | −0.940 |
+| HT precision | 0.000 | 0.496 | −0.496 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, while the
+tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse — predicts WT for everyone.** HT recall 0.0, HT precision 0.0, HT F1 0.0; WT
+  recall is 1.0. Balanced accuracy is exactly 0.500 and MCC is 0.000 — the model has learned nothing
+  beyond the majority class.
+- The headline "+0.035 accuracy vs base" is a **mirage**: it is simply the WT base rate (0.768 ≈ test WT
+  share 77%). Every minority-class metric is zero, so this run is useless for ASD-model detection.
+- AUC 0.682 / best val AUC 0.724 show the ranking signal is weak but non-random — the scores carry *some*
+  separation, yet the default 0.5 threshold never crosses for any HT session, so the decisions all fall
+  to WT.
+- Milder weighting (`beta=0.5`) was **not enough** to escape collapse on this tiny dependent split (244
+  train sessions); training loss kept dropping (0.79 → 0.53) while val AUC plateaued ~0.70, i.e. it
+  overfit the majority instead of learning HT.
+
+## Recommendations
+- Do not use this run. For the collapse, prefer the **D balanced-minibatch sampler** variant (the most
+  reliable fix per the experiment brief); the AUC≈0.68 here suggests the signal exists and a better
+  operating point / sampler could recover non-zero HT recall.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.682). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- `results.json` — full metrics, config, split sizes. `logs/out.txt` — flags, split info, per-epoch log, early stopping.
+- Metrics source: `results.json` + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/B_beta0.5__transformer__independent/README.md
+++ b/results/neural_networks/experiments/B_beta0.5__transformer__independent/README.md
@@ -1,0 +1,62 @@
+# B_beta0.5__transformer__independent — Transformer · subject-independent · experiment B (beta0.5)
+
+> Sequence Transformer on the baseline data, evaluated **leak-free** (split by mouse), with milder class weighting (`pos_weight_beta=0.5`).
+
+## Overview
+- **Model:** Transformer (~73K params) over the chronological per-syllable sequence (order preserved),
+  scored at **session level** — not the 48 aggregated per-recording features the tabular base uses.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice; test = 90 held-out sessions from 22 mice (WT 79% / HT 21%). Train 238 / val 80.
+- **What was adapted vs the base model (experiment B = beta0.5):** sequence Transformer instead of
+  XGBoost, subject-independent instead of dependent, and class weighting softened to
+  `pos_weight_beta=0.5` (effective `pos_weight=1.803`, sampler off, plain BCE). Trained 33 epochs,
+  early-stopped on best val AUC 0.807.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.848 | 0.375 | — |
+| Recall | 0.789 | 0.474 | — |
+| F1 | 0.818 | 0.419 | weighted **0.733** |
+| Accuracy | | | **0.722** (train 0.828) |
+
+Test AUC 0.725 · balanced acc 0.631 · PR-AUC 0.531 · MCC 0.242.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 56, WT→HT 15], [HT→WT 10, HT→HT 9]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.722 | 0.733 | −0.011 |
+| Weighted F1 | 0.733 | 0.749 | −0.016 |
+| WT F1 | 0.818 | 0.785 | +0.033 |
+| HT F1 | 0.419 | 0.649 | −0.230 |
+| HT recall | 0.474 | 0.940 | −0.466 |
+| HT precision | 0.375 | 0.496 | −0.121 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 90 session-level sequences, while the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- No degenerate collapse here — the milder weighting keeps both classes alive (HT recall 0.474, WT
+  recall 0.789), unlike the all-HT or all-WT failure modes common to these NN runs.
+- The minority class is the weak spot: **HT F1 collapses to 0.419** (−0.230 vs base) because the model
+  now both misses HT (recall 0.474, catches 9 of 19) **and** over-fires (precision 0.375) — only 9 of 24
+  HT predictions are correct. With 19 HT test sessions, every miss moves the metric a lot.
+- Headline accuracy (0.722) and weighted F1 (0.733) sit near the base, but that is carried by the
+  dominant WT class (F1 0.818); discrimination is mediocre — AUC 0.725, MCC 0.242, balanced acc 0.631.
+- Train 0.828 vs test 0.722 (0.11 gap) plus val AUC 0.807 vs test AUC 0.725 shows modest overfit and the
+  expected dependent→independent penalty on a tiny 90-session test set.
+
+## Recommendations
+- HT detection is poor at the 0.5 cut; for the minority class prefer the sampler-based fix (experiment D)
+  or focal loss (E) over softened weighting, and consider threshold tuning toward a target HT recall.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — normalized + raw-count confusion.
+- `plots/roc_curve.png` — ROC (test AUC 0.725). `plots/training_curves.png` — loss/acc/AUC over 33 epochs.
+- `model/transformer_best.pt` — best checkpoint (early-stopped). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split info, class balance and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/C_beta0__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/C_beta0__bilstm__dependent/README.md
@@ -1,0 +1,63 @@
+# C_beta0__bilstm__dependent — BiLSTM · subject-dependent · experiment C (no class weighting)
+
+> BiLSTM on chronological per-syllable sequences, trained with **no class weighting** and evaluated on a leaky (session-level) split.
+
+## Overview
+- **Model:** BiLSTM (~149K params; 2 layers, hidden 64, dropout 0.3) over the per-syllable acoustic
+  sequence in recording order (`max_seq_len` 256), scored at **session level** — not the tabular
+  recording level.
+- **Evaluation split:** subject-dependent — random **session-level** split (`group_split=false`), so the
+  same mouse leaks across train/val/test (log: 61 shared mice train/test). Optimistic by design.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice → train 244 / val 82 / test 82. Test = 82 sessions (WT 63 / HT 19, ~23% positive).
+- **What was adapted vs the base model:** experiment **C — beta0** (`pos_weight_beta=0.0`, sampler none,
+  plain BCE loss → `pos_weight=1.000`, i.e. **no class weighting**), plus the model family and input
+  representation change (BiLSTM on sequences vs XGBoost on 48 aggregated features).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.797 | 0.385 | — |
+| Recall | 0.873 | 0.263 | — |
+| F1 | 0.833 | 0.313 | weighted **0.713** |
+| Accuracy | | | **0.732** (train 0.865) |
+
+AUC 0.662 · balanced accuracy 0.568 · macro F1 0.573 · MCC 0.157 · PR-AUC 0.391.
+Early stopping at epoch 34/100 (best val AUC 0.665).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.732 | 0.733 | −0.001 |
+| Weighted F1 | 0.713 | 0.749 | −0.036 |
+| WT F1 | 0.833 | 0.785 | +0.048 |
+| HT F1 | 0.313 | 0.649 | −0.336 |
+| HT recall | 0.263 | 0.940 | −0.677 |
+| HT precision | 0.385 | 0.496 | −0.111 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, while the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- Removing class weighting tips the model toward the WT majority: **HT recall collapses to 0.263**
+  (−0.677 vs base) and HT F1 drops to 0.313, while accuracy survives (0.732) only because the test set is
+  ~77% WT. This is a majority-leaning failure — it misses ~3 of every 4 ASD-model pups.
+- HT precision is also weak (0.385): even the few positive calls it makes are wrong more often than not.
+  Balanced accuracy 0.568 and MCC 0.157 confirm the model is barely above chance on the minority class.
+- AUC 0.662 means the ranking signal exists but the **default 0.5 cut is mis-placed**; with no pos_weight
+  the threshold sits far on the WT side, the opposite of the base model's HT-heavy operating point.
+- Despite the leaky dependent split (which should be optimistic), this run still trails the tabular base
+  on every minority-class metric — the no-weighting lever, not the split, is the binding constraint.
+
+## Recommendations
+- Re-introduce minority-class pressure: the **D balanced-sampler** config is the most reliable fix for
+  this collapse; B (pos_weight_beta=0.5) and E (focal) are the next levers to try.
+- If keeping beta0, move the decision threshold off 0.5 toward HT to recover recall (AUC 0.662 leaves
+  headroom); evaluate against the leak-free independent split before trusting any number here.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.662). `plots/training_curves.png` — loss/acc/AUC vs epoch.
+- `model/bilstm_best.pt` — best checkpoint (epoch 34). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split info, data stats and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/C_beta0__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/C_beta0__bilstm__independent/README.md
@@ -1,0 +1,69 @@
+# C_beta0__bilstm__independent — BiLSTM · subject-independent · experiment C (no class weighting)
+
+> BiLSTM on chronological syllable sequences, evaluated **leak-free** (split by mouse), with class weighting switched **off** (`pos_weight_beta=0.0`).
+
+## Overview
+- **Model:** BiLSTM (2 layers, hidden 64, dropout 0.3; 148,953 params). Input is a chronological
+  per-syllable sequence (order preserved, capped at `max_seq_len=256`), unlike the tabular base model's
+  48 aggregated per-recording features. Scored at **session level**, not recording level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice → Train 238 / Val 80 / Test 90 sessions. Test = 22 held-out mice (WT 79% / HT 21%).
+- **What was adapted vs the base model:** experiment **C (beta0)** turns off class weighting entirely
+  (`pos_weight=1.000`, no sampler, plain BCE loss) — the opposite end from D's balanced sampler. Two
+  axes also change together: model family (BiLSTM instead of XGBoost) **and** evaluation moves from
+  subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.813 | 0.333 | — |
+| Recall | 0.859 | 0.263 | — |
+| F1 | 0.836 | 0.294 | weighted **0.721** |
+| Accuracy | | | **0.733** (train 0.866) |
+
+AUC-ROC 0.643 · PR-AUC 0.291 · balanced acc 0.561 · MCC 0.134 · macro F1 0.565.
+Early stopping at epoch 32 (best val AUC 0.795); the test AUC (0.643) sits well below it.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.733 | 0.733 | +0.000 |
+| Weighted F1 | 0.721 | 0.749 | −0.028 |
+| WT F1 | 0.836 | 0.785 | +0.051 |
+| HT F1 | 0.294 | 0.649 | −0.355 |
+| HT recall | 0.263 | 0.940 | −0.677 |
+| HT precision | 0.333 | 0.496 | −0.163 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 90 session-level sequences, whereas
+the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- With class weighting **off**, the model swings hard toward the majority: **HT recall collapses to
+  0.263** (−0.677 vs base) and HT F1 to 0.294, the mirror image of the base model's HT-heavy operating
+  point. It now misses ~3 of every 4 ASD-model pups — the opposite-direction failure from degenerate
+  HT-collapse, but just as damaging on the minority class.
+- Headline accuracy (0.733) ties the base only because it is carried by the majority class: WT F1 0.836
+  (+0.051) while HT contributes almost nothing. Balanced accuracy 0.561 and MCC 0.134 expose that the
+  classifier is barely above chance on the two-class problem.
+- Train 0.866 vs test 0.733 plus a test AUC (0.643) far below best val AUC (0.795) point to overfitting
+  on the small independent split (only 238 train / 56 HT sessions) — val loss bottoms out at epoch 17
+  (best val AUC) and climbs steadily thereafter while train accuracy keeps rising to ~0.94.
+
+## Recommendations
+- Removing class weighting is the wrong lever for this minority problem — prefer the balanced-sampler
+  config (experiment **D**, the most reliable collapse fix) or focal loss (**E**); for the tiny
+  independent split also try the regularized small net (**F**).
+- Do not use this run for any HT-detection estimate: at the default 0.5 cut HT recall is 0.263.
+  Threshold tuning toward `target_recall` could recover some, but PR-AUC 0.291 caps how much is
+  achievable here.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC. `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/C_beta0__cnn1d__dependent/README.md
+++ b/results/neural_networks/experiments/C_beta0__cnn1d__dependent/README.md
@@ -1,0 +1,64 @@
+# C_beta0__cnn1d__dependent — 1D-CNN · subject-dependent · experiment C (no class weighting)
+
+> 1D-CNN on the baseline sequence data with class weighting **off** (beta=0); the model collapses to all-WT.
+
+## Overview
+- **Model:** 1D-CNN over chronological per-syllable sequences (~86K params; `hidden_size` 64,
+  `num_layers` 2, dropout 0.3, `max_seq_len` 256). Scored at **session level**, not recording level.
+- **Evaluation split:** subject-dependent — random session-level split, so the **same mouse can sit in
+  train and test** (the log warns of 61 shared train/test mice). Optimistic/leaky, matching the base model.
+- **Dataset:** official baseline sequence cache — 408 sessions from 106 mice (HT=97, WT=311).
+  Test = 82 sessions (HT 23% / WT 77%). Train 244 / val 82.
+- **What was adapted vs base (lever C — beta0):** `pos_weight_beta=0.0` → **no class weighting**
+  (`pos_weight=1.000`, sampler none, BCE loss). With the minority class un-upweighted on top of the model
+  family change (1D-CNN vs XGBoost), training has no incentive to predict the 23% HT class.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.765 | 0.000 | — |
+| Recall | 0.984 | 0.000 | — |
+| F1 | 0.861 | 0.000 | weighted **0.662** |
+| Accuracy | | | **0.756** (train 0.799) |
+
+AUC 0.568 · balanced acc 0.492 · MCC −0.061 · PR-AUC 0.285 · best val AUC 0.714 · early-stopped epoch 21.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 62, WT→HT 1], [HT→WT 19, HT→HT 0]]` — every HT
+session is misclassified as WT.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.756 | 0.733 | +0.023 |
+| Weighted F1 | 0.662 | 0.749 | −0.087 |
+| WT F1 | 0.861 | 0.785 | +0.076 |
+| HT F1 | 0.000 | 0.649 | −0.649 |
+| HT recall | 0.000 | 0.940 | −0.940 |
+| HT precision | 0.000 | 0.496 | −0.496 |
+
+*Directional only: this NN is scored on **82 session-level sequences**, whereas the tabular base is scored
+on ~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- **Degenerate collapse to the majority class.** HT recall 0.000, HT F1 0.000, WT recall 0.984 — the
+  network predicts WT for all but one session. The headline 0.756 accuracy is just the WT base rate (77%),
+  not learning: balanced accuracy 0.492 and MCC −0.061 confirm performance at/below chance.
+- **Removing class weighting (beta0) is the direct cause.** With `pos_weight=1.000` and a 23% positive
+  rate, BCE is minimized by ignoring HT entirely. Train accuracy climbs to 0.91 by epoch 21 while val AUC
+  peaks at 0.714 then decays — the model overfits WT-leaning structure rather than separating classes.
+- Test AUC 0.568 (vs best val 0.714) shows the ranking ability barely beats random on the held-out
+  sessions, so the collapse is not just a threshold problem — there is little real signal to recover.
+- The +0.023 accuracy / +0.076 WT-F1 "wins" over the base are artifacts of the all-WT prediction; the
+  −0.940 HT-recall and −0.649 HT-F1 are the honest story.
+
+## Recommendations
+- Do not use this config — it is the negative control. Prefer the class-weighted / sampler variants
+  (lever **D** balanced sampler is the most reliable fix for this collapse; **B** beta0.5 is a milder
+  middle ground) for any usable dependent-split CNN.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (all HT → WT).
+- `plots/roc_curve.png` — ROC (test AUC 0.568). `plots/training_curves.png` — loss/acc/AUC over 21 epochs.
+- `model/cnn1d_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split/data stats and early-stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/C_beta0__cnn1d__independent/README.md
+++ b/results/neural_networks/experiments/C_beta0__cnn1d__independent/README.md
@@ -1,0 +1,64 @@
+# C_beta0__cnn1d__independent — 1D-CNN · subject-independent · experiment C (beta0, no class weighting)
+
+> 1D-CNN on per-syllable sequences, evaluated **leak-free** (split by mouse), with class weighting switched off.
+
+## Overview
+- **Model:** 1D-CNN (86,041 params) over a chronological per-syllable sequence (`max_seq_len=256`),
+  not the 48 aggregated per-recording features the tabular base uses. Scored at **session level**.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  group-aware), so no mouse appears in two sets. Honest "generalize to unseen mice" setting, harder than
+  the dependent base model (which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice → train 238 / val 80 / test 90 sessions. Test = 22 held-out mice (WT 79% / HT 21%).
+- **What was adapted vs the base model (experiment C, beta0):** `pos_weight_beta=0.0` →
+  **no class weighting** (`pos_weight=1.000`, plain BCE, no sampler), on top of the model-family +
+  dependent→independent change. Trained 25 epochs, early-stopped on val AUC (best 0.752).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.809 | 0.273 | — |
+| Recall | 0.775 | 0.316 | — |
+| F1 | 0.791 | 0.293 | weighted **0.686** |
+| Accuracy | | | **0.678** (train 0.836) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 55, WT→HT 16], [HT→WT 13, HT→HT 6]]` (90 sessions).
+Test AUC 0.517 · balanced acc 0.545 · MCC 0.086 · PR-AUC 0.297.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.678 | 0.733 | −0.055 |
+| Weighted F1 | 0.686 | 0.749 | −0.063 |
+| WT F1 | 0.791 | 0.785 | +0.006 |
+| HT F1 | 0.293 | 0.649 | −0.356 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.273 | 0.496 | −0.223 |
+
+*Directional only: this NN is scored on ~90 session-level sequences, whereas the tabular base is scored on ~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- **No collapse, but the minority class barely works.** With class weighting off, the model defaults
+  toward the WT majority: HT recall 0.316 and HT precision 0.273 → **HT F1 0.293** (−0.356 vs base). It
+  catches only 6 of 19 HT sessions while the base flags 94% of HT.
+- **No real signal at test.** Test AUC 0.517 (≈ chance), MCC 0.086, balanced acc 0.545 — the run sits
+  just above coin-flip on the held-out mice despite val AUC reaching 0.752, a sharp val→test drop typical
+  of the tiny independent split (238 train sessions).
+- **Overfitting.** Train acc 0.836 vs test 0.678 (0.16 gap); train loss falls to ~0.19 while val loss
+  rises after epoch 9 — early stopping fired at epoch 25.
+- WT F1 (0.791) edges out base only because the model leans WT; this does not reflect genuine WT vs HT
+  separation.
+
+## Recommendations
+- Removing class weighting hurts the minority class here. Prefer the **D (balanced sampler)** config —
+  the most reliable collapse/imbalance fix in this sweep — over beta0 for the independent split.
+- Given near-chance test AUC on 90 sessions, treat this CNN as not viable for new-mouse HT detection;
+  the tabular independent runs remain the better honest estimate.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC. `plots/training_curves.png` — train/val loss, acc, AUC over epochs.
+- `model/cnn1d_best.pt` — best checkpoint (by val AUC). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; `logs/out.txt` — flags, split/class balance, per-epoch log, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/C_beta0__transformer__dependent/README.md
+++ b/results/neural_networks/experiments/C_beta0__transformer__dependent/README.md
@@ -1,0 +1,66 @@
+# C_beta0__transformer__dependent — Transformer · subject-dependent · experiment C (no class weighting)
+
+> Sequence Transformer on the baseline data, subject-dependent split, with class weighting turned **off** (`pos_weight_beta=0.0`).
+
+## Overview
+- **Model:** Transformer (~73K params; 2 layers, `d_model`=64, dropout 0.3) over the chronological
+  per-syllable sequence (order preserved, `max_seq_len`=256), scored at **session level** — not the 48
+  aggregated per-recording features the tabular base uses.
+- **Evaluation split:** subject-dependent — random session-level split (`group_split=false`), so the same
+  mouse can land in train and test (leakage, optimistic). Log confirms mouse overlap: 61 shared mice
+  train/test, 56 train/val.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311); median sequence length 236 syllables (P95 704).
+- **What was adapted vs the base model (lever C):** class weighting is **disabled** — `pos_weight_beta=0.0`
+  gives `pos_weight=1.0` with `loss=bce`, no sampler. The minority HT class gets no upweighting at all.
+- **Train/val/test:** 244 / 82 / 82 sessions; HT share ~24% in each. Early-stopped at epoch 48 (best val
+  AUC 0.727).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.781 | 0.333 | — |
+| Recall | 0.905 | 0.158 | — |
+| F1 | 0.838 | 0.214 | weighted **0.694** |
+| Accuracy | | | **0.732** (train 0.848) |
+
+AUC-ROC 0.702 · PR-AUC 0.385 · balanced accuracy 0.531 · MCC 0.085 (82 test sessions).
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 57, WT→HT 6], [HT→WT 16, HT→HT 3]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.732 | 0.733 | −0.001 |
+| Weighted F1 | 0.694 | 0.749 | −0.055 |
+| WT F1 | 0.838 | 0.785 | +0.053 |
+| HT F1 | 0.214 | 0.649 | −0.435 |
+| HT recall | 0.158 | 0.940 | −0.782 |
+| HT precision | 0.333 | 0.496 | −0.163 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, whereas the tabular base reports recording-level metrics over ~2,465 rows.*
+
+## Key insights
+- **Near-collapse toward WT.** With class weighting off, the Transformer predicts WT for almost everyone:
+  HT recall 0.158 (only 3 of 19 HT sessions caught), HT F1 0.214, balanced accuracy 0.531 and MCC 0.085 —
+  barely above chance despite a headline accuracy of 0.732 that just tracks the 77% WT prior.
+- **Accuracy is a mirage here.** Test accuracy matches the base (−0.001) only because the majority class
+  dominates; on the minority ASD-model class the model is far worse (HT recall −0.782, HT F1 −0.435 vs base).
+- **The lever is the cause.** `pos_weight_beta=0.0` removes any minority upweighting, so the easy WT-everyone
+  solution wins. This is the expected failure mode of the C config and the foil for the weighted/sampler
+  experiments (B/D).
+- AUC 0.702 shows the ranking is non-trivial — the signal exists — but the default 0.5 cut sits in the wrong
+  place; train 0.848 vs test 0.732 indicates mild overfit on top of the collapse.
+
+## Recommendations
+- Do not use this config for HT detection. Prefer the class-balancing experiments — D (balanced minibatch
+  sampler) is the most reliable collapse fix, with B (`beta=0.5`) and E (focal) as alternatives.
+- If this checkpoint must be reused, its AUC 0.702 still ranks; move the decision threshold well below 0.5 to
+  recover HT recall before trusting any positive call.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (AUC 0.702). `plots/training_curves.png` — loss/accuracy/AUC over 48 epochs.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split/training detail: `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/C_beta0__transformer__independent/README.md
+++ b/results/neural_networks/experiments/C_beta0__transformer__independent/README.md
@@ -1,0 +1,66 @@
+# C_beta0__transformer__independent — Transformer · subject-independent · experiment C (no class weighting)
+
+> Transformer on per-syllable sequences, leak-free split, with class weighting turned **off** — collapses to predicting WT for every session.
+
+## Overview
+- **Model:** Transformer (~73K params; 2 layers, d_model 64, dropout 0.3). Input is the chronological
+  per-syllable sequence (order preserved, `MAX_SEQ_LEN=256`), not the 48 aggregated tabular features.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware), so no mouse appears in two sets. Honest "generalize to unseen mice" setting (harder than
+  the dependent base model, which splits rows randomly and leaks mice across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice → train 238 / val 80 / test 90 sessions. Test = 22 held-out mice (WT 79% / HT 21%).
+- **What was adapted vs the base model:** experiment **C = beta0** — `pos_weight_beta=0.0`, i.e. **no
+  class weighting** (`pos_weight=1.000`), plain BCE, no sampler/focal/augmentation. Scored at session
+  level, not recording level.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.789 | 0.000 | — |
+| Recall | 1.000 | 0.000 | — |
+| F1 | 0.882 | 0.000 | weighted **0.696** |
+| Accuracy | | | **0.789** (train 0.765) |
+
+AUC 0.710 · balanced accuracy 0.500 · MCC 0.000 · macro F1 0.441 · best val AUC 0.781 · early stop epoch 22/100.
+
+**Degenerate collapse:** the model predicts **WT for all 90 test sessions** — HT recall 0.000, HT F1
+0.000, WT recall 1.000. Accuracy 0.789 is exactly the WT prior (71/90), so the classifier learns nothing
+discriminative at the 0.5 cut despite a non-trivial AUC of 0.710.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.789 | 0.733 | +0.056 |
+| Weighted F1 | 0.696 | 0.749 | −0.053 |
+| WT F1 | 0.882 | 0.785 | +0.097 |
+| HT F1 | 0.000 | 0.649 | −0.649 |
+| HT recall | 0.000 | 0.940 | −0.940 |
+| HT precision | 0.000 | 0.496 | −0.496 |
+
+*Directional only: this NN is scored on session-level sequence data (90 test sessions) while the tabular
+base is scored on recording-level data (~2,465 rows) — not a like-for-like comparison.*
+
+## Key insights
+- **Collapse, not generalization.** The +0.056 accuracy gain over base is an artifact of always
+  guessing the majority class — every HT metric is 0.000. The model identifies zero ASD-model pups.
+- **Removing class weighting causes it.** With `pos_weight=1.000` (beta0) and a 24% minority, plain BCE
+  has no pressure to predict HT; train accuracy (0.765) also sits near the train WT prior, so collapse
+  starts in training, not just at the decision threshold.
+- **Signal exists but is unused.** Val AUC peaked at 0.781 and test AUC is 0.710 — ranking is better than
+  chance, yet the fixed 0.5 cut maps all probabilities below it. A threshold sweep or class rebalancing
+  would be required to recover any HT.
+
+## Recommendations
+- Use a class-imbalance lever instead of beta0: the **D balanced sampler** is the most reliable fix for
+  this collapse; B (beta0.5) or E (focal) are alternatives.
+- If keeping this run, do not score at the default 0.5 cut — calibrate a threshold against the 0.710 AUC;
+  but the absent HT signal at this operating point makes this run unfit as a "new-mouse" estimate.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (all sessions → WT).
+- `plots/roc_curve.png` — ROC (AUC 0.710). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/D_sampler__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/D_sampler__bilstm__dependent/README.md
@@ -1,0 +1,67 @@
+# D_sampler__bilstm__dependent — BiLSTM · subject-dependent · D balanced-sampler experiment
+
+> BiLSTM on the official baseline data, evaluated on the **optimistic** (leaky) session-level split, with a balanced minibatch sampler as the anti-collapse lever.
+
+## Overview
+- **Model:** BiLSTM (~149K params; 2 layers, hidden 64, dropout 0.3). Input is a chronological
+  per-syllable sequence (order preserved), scored at the **session level**, unlike the tabular base
+  model's 48 aggregated per-recording features.
+- **Evaluation split:** subject-dependent — random session-level split (`subject_eval_independent=false`,
+  `group_split=false`), so the same mouse can appear in train and test (the log warns of 61 shared
+  train/test mice). This is the optimistic, leaky setting that flatters scores.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  408 sessions from 106 mice (HT 97 / WT 311). Test = 82 sessions (WT 63 / HT 19, ~23% HT).
+- **What was adapted vs the base model:** the **D lever** — a balanced minibatch sampler with class
+  weighting off (`pos_weight_beta=0.0`, `sampler=balanced`, `loss=bce`) — the most reliable fix for
+  degenerate collapse. Note this also swaps model family (BiLSTM vs XGBoost) and granularity (sessions
+  vs recordings).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.836 | 0.370 | — |
+| Recall | 0.730 | 0.526 | — |
+| F1 | 0.780 | 0.435 | weighted **0.700** |
+| Accuracy | | | **0.683** (train 0.738) |
+
+Test AUC-ROC 0.776 · PR-AUC 0.526 · balanced acc 0.628 · MCC 0.230. Best val AUC 0.820 (epoch 1),
+early-stopped at epoch 16 / 100.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.683 | 0.733 | −0.050 |
+| Weighted F1 | 0.700 | 0.749 | −0.049 |
+| WT F1 | 0.780 | 0.785 | −0.005 |
+| HT F1 | 0.435 | 0.649 | −0.214 |
+| HT recall | 0.526 | 0.940 | −0.414 |
+| HT precision | 0.370 | 0.496 | −0.126 |
+
+*Comparison is directional, not like-for-like: this BiLSTM is scored on 82 session-level sequences,
+whereas the tabular base reports recording-level metrics over ~2,465 rows.*
+
+## Key insights
+- **No collapse** — the balanced sampler did its job: the model predicts both classes (HT recall 0.526,
+  WT recall 0.730), avoiding the degenerate all-HT or all-WT failure that plagues the un-sampled NN runs.
+- But the operating point is weak on the minority class: **HT precision 0.370 and HT F1 0.435** mean
+  about 2 in 3 HT calls are false positives and roughly half the ASD-model sessions are missed.
+- Despite the leaky dependent split, every headline metric trails the tabular base (accuracy −0.050,
+  weighted F1 −0.049, HT recall −0.414); MCC 0.230 confirms only modest class separation.
+- Training is unstable and front-loaded — **best val AUC (0.820) lands at epoch 1**, then drifts down
+  while train accuracy climbs to 0.779; the 0.05 train/test accuracy gap is small only because val/test
+  performance never improved past the start.
+
+## Recommendations
+- The sampler fixes collapse but not class separation; HT precision 0.37 makes positive calls
+  unreliable. Compare against the CV variant (`../H_cv_Dsampler__bilstm__dependent/`) to gauge whether
+  this single split is representative before trusting these numbers.
+- For any honest generalization estimate, prefer the subject-independent runs — this dependent split
+  leaks 61 mice across train/test and still underperforms the tabular base.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC curve (test AUC 0.776). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/D_sampler__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/D_sampler__bilstm__independent/README.md
@@ -1,0 +1,67 @@
+# D_sampler__bilstm__independent — BiLSTM · subject-independent · D balanced-sampler experiment
+
+> BiLSTM with a balanced minibatch sampler on the leak-free (by-mouse) split — the collapse fix that here over-corrects toward the HT minority.
+
+## Overview
+- **Model:** BiLSTM (~149K params; 2 layers, hidden 64, dropout 0.3). Input is a chronological
+  per-syllable sequence (order preserved), scored at the **session** level — unlike the tabular base
+  model's 48 aggregated per-recording features.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  group-aware), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice → Train 238 (63 mice) / Val 80 (21 mice) / **Test 90 sessions (22 mice, HT 21% / WT 79%)**.
+- **What was adapted vs the base model (lever D):** add a **balanced minibatch sampler** to fight
+  degenerate collapse, with class weighting turned off (`pos_weight_beta=0.0`, `loss=bce`); plus the
+  two structural changes shared by all NN runs — model family (BiLSTM instead of XGBoost) **and**
+  evaluation moving from subject-dependent to subject-independent.
+- Trained 17/100 epochs (early stop, best val AUC 0.865).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 1.000 | 0.311 | — |
+| Recall | 0.408 | 1.000 | — |
+| F1 | 0.580 | 0.475 | weighted **0.558** |
+| Accuracy | | | **0.533** (train 0.681) |
+
+Other test metrics: AUC-ROC 0.767 · balanced accuracy 0.704 · PR-AUC 0.354 · MCC 0.357 · macro-F1 0.528.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.533 | 0.733 | −0.200 |
+| Weighted F1 | 0.558 | 0.749 | −0.191 |
+| WT F1 | 0.580 | 0.785 | −0.205 |
+| HT F1 | 0.475 | 0.649 | −0.174 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.311 | 0.496 | −0.185 |
+
+*Directional comparison only: this NN is scored on **90 session-level sequences**, while the tabular base is scored on ~2,465 recording-level rows — not a like-for-like split or unit.*
+
+## Key insights
+- **Degenerate collapse toward the minority.** The sampler over-corrects: **HT recall = 1.000 with WT
+  recall only 0.408** — the model calls HT for the majority of sessions. HT precision is just 0.311
+  (~7 in 10 HT calls are false positives), so the +0.060 HT-recall "win" vs base is hollow.
+- Accuracy (0.533) and weighted F1 (0.558) sit ~0.19–0.20 below the dependent base, the worst possible
+  side of the collapse — every WT cost is paid to chase HT recall.
+- Ranking is healthier than the operating point: **AUC-ROC 0.767 / balanced accuracy 0.704 / MCC 0.357**
+  show the model does separate the classes; the default 0.5 threshold is simply mis-placed far into the
+  HT-favoring region.
+- WT precision pinned at 1.000 with recall 0.408 is the signature of this regime — every WT prediction
+  is correct, but only 4 in 10 WT sessions are recovered.
+
+## Recommendations
+- Do not ship the 0.5 cut. With AUC 0.767 there is room to recover via thresholding — pick a cut that
+  trades the saturated HT recall back for WT recall before reading any per-class metric.
+- The balanced sampler alone over-shoots on this tiny independent split; compare against the
+  regularized-small variant (lever F) and the focal/beta variants, and prefer the CV config (lever H)
+  for a stable estimate before trusting any single 90-session test number.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (AUC 0.767). `plots/training_curves.png` — loss/acc/AUC over 17 epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/D_sampler__cnn1d__dependent/README.md
+++ b/results/neural_networks/experiments/D_sampler__cnn1d__dependent/README.md
@@ -1,0 +1,47 @@
+# D_sampler__cnn1d__dependent — 1D-CNN · subject-dependent · D balanced sampler
+
+> 1D-CNN over per-syllable sequences, with a balanced minibatch sampler (no loss class-weighting), on the official baseline data — evaluated subject-dependent (mice leak across splits).
+
+## Overview
+- **Model:** 1D-CNN (~86K params) over a chronological per-syllable sequence (order preserved, `max_seq_len=256`), scored at the **session** level — unlike the tabular base, which uses 48 aggregated per-recording features.
+- **Evaluation split:** subject-dependent — random session-level split (`subject_eval_independent=false`, `group_split=false`). The log confirms heavy leakage: **61 mice shared between train and test**, 56 between train and val. Optimistic by design.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106 mice; train 244 / val 82 / test 82 sessions, all at HT≈24% / WT≈76%.
+- **What was adapted vs the base model:** the **D lever** — a balanced minibatch sampler oversamples the HT minority, while loss class-weighting is turned off (`pos_weight_beta=0.0`, `pos_weight=1.000`, `loss=bce`). This is the most reliable fix for degenerate collapse. Trained 22/100 epochs (early stop, best val AUC 0.722).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.818 | 0.333 | — |
+| Recall | 0.714 | 0.474 | — |
+| F1 | 0.763 | 0.391 | weighted **0.677** |
+| Accuracy | | | **0.659** (train 0.783) |
+
+AUC 0.590 · balanced acc 0.594 · MCC 0.169 · PR-AUC 0.298 (best val AUC 0.722).
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 45, WT→HT 18], [HT→WT 10, HT→HT 9]]` (WT support 63, HT support 19).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.659 | 0.733 | −0.074 |
+| Weighted F1 | 0.677 | 0.749 | −0.072 |
+| WT F1 | 0.763 | 0.785 | −0.022 |
+| HT F1 | 0.391 | 0.649 | −0.258 |
+| HT recall | 0.474 | 0.940 | −0.466 |
+| HT precision | 0.333 | 0.496 | −0.163 |
+
+*Directional comparison only: this NN is scored on session-level sequence data (82 test sessions) while the tabular base is scored at recording level (~2,465 rows), so these are not like-for-like.*
+
+## Key insights
+- The balanced sampler **avoids degenerate collapse** — both classes are predicted (HT recall 0.474, WT recall 0.714, neither at 0 or 1), which is the intended effect of the D lever versus the all-one-class failure mode.
+- But it does not buy real separation: **AUC 0.590** and MCC 0.169 are barely above chance, and **HT precision is just 0.333** — two of every three HT predictions are false positives, so HT F1 collapses to 0.391 (−0.258 vs base).
+- Despite leakage that should flatter the dependent split, every headline metric trails the tabular base: test accuracy −0.074, HT recall −0.466. The sampler trades the base model's near-perfect HT recall (0.940) for a far more conservative, lower-quality operating point.
+- Train 0.783 vs test 0.659 with val accuracy oscillating (0.39–0.68 across epochs while val AUC peaked early at 0.722) signals an unstable, noisy fit on only 244 training sessions.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.590). `plots/training_curves.png` — loss/acc/AUC over 22 epochs.
+- `model/cnn1d_best.pt` — best-val checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, leakage warning, class balance).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/D_sampler__cnn1d__independent/README.md
+++ b/results/neural_networks/experiments/D_sampler__cnn1d__independent/README.md
@@ -1,0 +1,62 @@
+# D_sampler__cnn1d__independent — 1D-CNN · subject-independent · D balanced sampler
+
+> 1D-CNN on per-syllable sequences, leak-free split by mouse, with a balanced minibatch sampler to fight collapse.
+
+## Overview
+- **Model:** 1D-CNN over the chronological per-syllable sequence (order preserved), 86,041 params.
+  Input is the raw syllable stream (`max_seq_len` 256), not the 48 aggregated per-recording features the
+  tabular base uses; scoring is at **session** level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  `--group-split`), so no mouse appears in two sets. Honest "generalize to unseen mice" setting (harder
+  than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice → train 238 / val 80 / test 90 sessions. Test = 22 held-out mice (WT 79% / HT 21%).
+- **What was adapted vs the base model (lever D):** model family swaps to a 1D-CNN on sequences, the
+  evaluation moves dependent → independent, **and** a balanced minibatch sampler replaces class
+  weighting (`pos_weight_beta=0.0`, `sampler=balanced`, `loss=bce`) — the most reliable fix for the
+  degenerate collapse the NN runs hit on this tiny split.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.800 | 0.267 | — |
+| Recall | 0.845 | 0.211 | — |
+| F1 | 0.822 | 0.235 | weighted **0.698** |
+| Accuracy | | | **0.711** (train 0.761) |
+
+Test AUC 0.557 · balanced accuracy 0.528 · MCC 0.061 · PR-AUC 0.359. Best val AUC 0.770; early stopped
+at epoch 17/100.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.711 | 0.733 | −0.022 |
+| Weighted F1 | 0.698 | 0.749 | −0.051 |
+| WT F1 | 0.822 | 0.785 | +0.037 |
+| HT F1 | 0.235 | 0.649 | −0.414 |
+| HT recall | 0.211 | 0.940 | −0.729 |
+| HT precision | 0.267 | 0.496 | −0.229 |
+
+*Directional only: this NN is scored on ~90 session-level sequences, while the tabular base is scored on
+~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- The balanced sampler **avoids the all-HT collapse** seen elsewhere, but trades into the opposite
+  failure: the model leans toward WT (WT recall 0.845) and the minority class falls apart —
+  **HT recall 0.211, HT F1 0.235**, catching ~1 in 5 ASD-model sessions. HT precision 0.267 means most
+  of the few HT calls are also wrong.
+- Discrimination is near chance on the held-out mice: **test AUC 0.557, balanced accuracy 0.528,
+  MCC 0.061** — the 0.711 accuracy is essentially the WT base rate (79%), not real signal.
+- The big val→test gap (best val AUC 0.770 vs test AUC 0.557) on only 22 test mice shows severe
+  overfitting to the validation fold; the model does not generalize to unseen subjects.
+- WT F1 beats the base (+0.037) only because the run defaults to predicting the majority; that is not a
+  win — every minority-class metric collapses (HT F1 −0.414, HT recall −0.729).
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (test AUC 0.557). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint (epoch with val AUC 0.770). `model/scaler.pkl` — feature scaler.
+- `logs/out.txt` — flags, split info, class balance, per-epoch log, early stopping.
+- Metrics source: `results.json` + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/D_sampler__transformer__dependent/README.md
+++ b/results/neural_networks/experiments/D_sampler__transformer__dependent/README.md
@@ -1,0 +1,68 @@
+# D_sampler__transformer__dependent — Transformer · subject-dependent · D balanced-sampler experiment
+
+> Transformer on per-syllable USV sequences with a balanced minibatch sampler, evaluated on the leaky (row-level) dependent split.
+
+## Overview
+- **Model:** Transformer (~73K params; chronological per-syllable sequence input, order preserved,
+  scored at the session level — unlike the tabular base's 48 aggregated per-recording features).
+- **Evaluation split:** subject-dependent — random **session-level** split (`group_split=false`), so the
+  same mouse appears in train, val and test (the log warns of 61 shared train/test mice). This is the
+  leaky, optimistic setting, matching the dependent base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  408 sessions from 106 mice (HT 97 / WT 311); split 244 train / 82 val / 82 test sessions.
+  Test = 82 sessions (WT 63 / HT 19 ≈ 23% positive).
+- **What was adapted vs the base model:** lever **D** — a **balanced minibatch sampler** (the most
+  reliable fix for collapse) replaces XGBoost. Class weighting is off (`pos_weight_beta=0.0`, `loss=bce`),
+  so the sampler alone carries the imbalance handling. Trained 25 epochs (early-stopped, best val AUC 0.706).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.806 | 0.400 | — |
+| Recall | 0.857 | 0.316 | — |
+| F1 | 0.831 | 0.353 | weighted **0.720** |
+| Accuracy | | | **0.732** (train 0.774) |
+
+AUC 0.652 · balanced accuracy 0.586 · MCC 0.189 · PR-AUC 0.341.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 54, WT→HT 9], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.732 | 0.733 | −0.001 |
+| Weighted F1 | 0.720 | 0.749 | −0.029 |
+| WT F1 | 0.831 | 0.785 | +0.046 |
+| HT F1 | 0.353 | 0.649 | −0.296 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.400 | 0.496 | −0.096 |
+
+*NN are scored on session-level sequence data (82 test sessions here) vs the tabular base's recording-level
+data (~2,465 rows), so this comparison is directional, not like-for-like.*
+
+## Key insights
+- **The sampler did not deliver minority-class performance here.** Overall accuracy (0.732) matches the
+  base, but it is carried entirely by WT (recall 0.857, F1 0.831) — **HT recall collapses to 0.316**
+  (−0.624 vs base) and HT F1 to 0.353. The model now catches only 6 of 19 ASD-model sessions.
+- This is the **opposite of the classic "predict HT for everyone" collapse**: the sampler pushed the
+  model toward the WT majority instead, so it misses two-thirds of positives. With no class weighting,
+  random per-session sampling alone was not enough to hold the operating point on the minority class.
+- Weak class separation overall — **AUC 0.652, balanced accuracy 0.586, MCC 0.189** — barely above
+  chance on a leaky split that should be the *easy* setting. Val AUC peaked at 0.706 by epoch 10 then
+  drifted, while val accuracy oscillated wildly (0.37–0.77), a sign of an unstable fit on only 244 train
+  sessions.
+- Even with mouse leakage in its favour, this Transformer is well below the tabular base on every
+  minority-class metric; the 73K-param model is data-starved at session granularity.
+
+## Recommendations
+- Pair the balanced sampler with explicit class weighting (compare against the B/A/E levers) — sampler
+  alone left the positive class under-served. Threshold tuning cannot rescue an AUC of 0.652.
+- Treat session-level NN counts (82 test sessions, 19 HT) as too small for confident minority-class
+  estimates; the dependent split's optimism is not even visible here.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — test confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.652). `plots/training_curves.png` — loss/accuracy/AUC over 25 epochs.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- `results.json` — full metrics, config, split sizes. `logs/out.txt` — flags, split info, class balance, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/D_sampler__transformer__independent/README.md
+++ b/results/neural_networks/experiments/D_sampler__transformer__independent/README.md
@@ -1,0 +1,71 @@
+# D_sampler__transformer__independent — Transformer · subject-independent · D balanced-sampler experiment
+
+> Transformer on per-syllable sequences, evaluated **leak-free** with a balanced minibatch sampler — and it still collapsed onto HT.
+
+## Overview
+- **Model:** Transformer (~73K params; chronological per-syllable sequence input, `max_seq_len=256`,
+  `d_model=64`, 2 layers, dropout 0.3). Scored at **session level**, not recording level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  `--group-split`), so no mouse appears in two sets. Honest "generalize to unseen mice" setting (harder
+  than the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice → train 238 (63 mice, 24% HT) · val 80 (21 mice) · **test 90 sessions** (22 mice, HT 21% / WT 79%).
+- **What was adapted vs the base model (lever D):** balanced minibatch **sampler** (`sampler=balanced`)
+  with class weighting off (`pos_weight_beta=0.0`, `loss=bce`) — the usual most-reliable fix for
+  collapse — on top of the model-family change (Transformer instead of XGBoost) and the dependent →
+  subject-independent split change.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 1.000 | 0.213 | — |
+| Recall | 0.014 | 1.000 | — |
+| F1 | 0.028 | 0.352 | weighted **0.096** |
+| Accuracy | | | **0.222** (train 0.269) |
+
+AUC-ROC 0.749 · PR-AUC 0.558 · balanced acc 0.507 · MCC 0.055 · best val AUC 0.824 · early-stopped at
+epoch 19/100. Confusion matrix (rows = true, cols = pred): `[[WT→WT 1, WT→HT 70], [HT→WT 0, HT→HT 19]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.222 | 0.733 | −0.511 |
+| Weighted F1 | 0.096 | 0.749 | −0.653 |
+| WT F1 | 0.028 | 0.785 | −0.757 |
+| HT F1 | 0.352 | 0.649 | −0.297 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.213 | 0.496 | −0.283 |
+
+*Directional only, not like-for-like: this NN is scored on 90 session-level sequences vs the tabular
+base's ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse.** The model predicts **HT for nearly every session** — HT recall 1.000, WT
+  recall 0.014 (1 of 71 WT sessions correct). Accuracy 0.222 just tracks the HT base rate. The balanced
+  sampler (lever D) did **not** prevent collapse here; it tipped the model the opposite way from the
+  WT-everyone failure.
+- **Ranking ≠ thresholding.** Test AUC-ROC is a respectable 0.749 (best val AUC 0.824), so the network
+  learned *some* separation, but the default 0.5 cut sits entirely on one side — MCC 0.055 and balanced
+  accuracy 0.507 confirm the operating point is no better than chance.
+- **Training never settled.** Val accuracy swung wildly epoch-to-epoch (0.31 → 0.78) while AUC peaked at
+  0.824 by epoch 4; early stopping on AUC locked in a checkpoint whose decision boundary is degenerate.
+  Train accuracy 0.269 (also below the WT majority rate) signals the sampler is over-balancing the
+  minority class.
+- The +0.060 HT-recall "win" over base is meaningless — it is the artifact of calling everything HT,
+  paid for with WT F1 collapsing to 0.028.
+
+## Recommendations
+- Do **not** use this checkpoint. AUC 0.749 shows signal exists, so re-threshold off the probability
+  ranking — a recall-targeted cut (e.g. `target_recall` ~0.80) tuned on the validation logits — rather
+  than trusting the degenerate 0.5 cut.
+- The balanced sampler alone over-corrects on this tiny independent split (238 train sessions); compare
+  against the regularized lever-F run and the CV lever-H run (`H_cv_Dsampler__*`) before drawing any
+  conclusion on the sampler fix for the Transformer.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — ROC (AUC 0.749). `plots/training_curves.png` — loss/acc/AUC over 19 epochs.
+- `model/transformer_best.pt` — best checkpoint (val AUC). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/E_focal__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/E_focal__bilstm__dependent/README.md
@@ -1,0 +1,66 @@
+# E_focal__bilstm__dependent — BiLSTM · subject-dependent · experiment E (focal loss)
+
+> BiLSTM on per-syllable sequences with **focal loss** and no class weighting, evaluated on the leaky subject-dependent split.
+
+## Overview
+- **Model:** BiLSTM (~149K params, hidden 64, 2 layers, dropout 0.3) over chronological per-syllable
+  sequences (order preserved, `max_seq_len=256`), unlike the tabular base which uses 48 aggregated
+  per-recording features. Scored at **session level**.
+- **Evaluation split:** subject-dependent — random session-level split (`subject_eval_independent=false`,
+  `group_split=false`). The log confirms heavy leakage: 61 mice shared between train and test, 56 between
+  train and val. Optimistic, like the base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106 mice;
+  Train 244 / Val 82 / Test 82, HT ≈ 23–24% throughout.
+- **What was adapted vs the base model (lever E):** loss switched to **focal loss** (`focal_gamma=2.0`) with
+  **no class weighting and no sampler** (`pos_weight_beta=0.0`, `sampler=none`, effective `pos_weight=1.000`).
+  Trained 29 epochs, early-stopped on val AUC (best 0.702).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.778 | 0.300 | — |
+| Recall | 0.889 | 0.158 | — |
+| F1 | 0.830 | 0.207 | weighted **0.685** |
+| Accuracy | | | **0.720** (train 0.824) |
+
+Test AUC 0.679 · balanced acc 0.523 · MCC 0.060 · PR-AUC 0.402.
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 56, WT→HT 7], [HT→WT 16, HT→HT 3]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.720 | 0.733 | −0.013 |
+| Weighted F1 | 0.685 | 0.749 | −0.064 |
+| WT F1 | 0.830 | 0.785 | +0.045 |
+| HT F1 | 0.207 | 0.649 | −0.442 |
+| HT recall | 0.158 | 0.940 | −0.782 |
+| HT precision | 0.300 | 0.496 | −0.196 |
+
+*Directional only, not like-for-like: this NN is scored on 82 session-level sequences, whereas the tabular
+base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Minority-class failure.** Focal loss without any class weighting tilts the model toward the majority:
+  HT recall collapses to **0.158** (3 of 19 HT sessions caught) and HT F1 drops to **0.207** — the opposite
+  failure mode from a HT-everyone collapse. MCC 0.060 and balanced accuracy 0.523 confirm the model is
+  barely above chance on the harder axis despite headline accuracy 0.720.
+- **Accuracy is carried entirely by WT.** WT F1 0.830 (+0.045 vs base) is the only metric that beats the
+  base; the 0.720 accuracy mostly reflects the 77% WT prior, not genuine class separation.
+- **Overfitting on a leaky split.** Train accuracy 0.824 vs test 0.720, with val loss rising monotonically
+  after ~epoch 9 while train loss keeps falling — early stopping fired at epoch 29 on a flat val AUC ≈ 0.70.
+  Even with train/test mouse leakage, the model does not transfer to the minority class.
+
+## Recommendations
+- Focal loss alone underweights HT here. Prefer the **balanced sampler** (lever D) or explicit `pos_weight`
+  (levers A/B) to recover HT recall; focal could be revisited only combined with class weighting.
+- Do not use this run for any honest generalization estimate — the split leaks mice across train/test.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.679). `plots/training_curves.png` — loss/acc/AUC over 29 epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler. `logs/out.txt` — flags,
+  split/leakage info, class balance, per-epoch log, test report.
+- Metrics source: `results.json` + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/E_focal__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/E_focal__bilstm__independent/README.md
@@ -1,0 +1,68 @@
+# E_focal__bilstm__independent — BiLSTM · subject-independent · experiment E (focal loss)
+
+> BiLSTM with focal loss (no class weighting) on the baseline data, evaluated **leak-free** (split by mouse) — collapses toward WT.
+
+## Overview
+- **Model:** BiLSTM (~149K params; bidirectional LSTM over chronological per-syllable sequences, order
+  preserved — unlike the tabular base, which uses 48 aggregated per-recording features). Scored at
+  **session level**, not recording level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  `--group-split`), so no mouse appears in two sets. The honest "generalize to unseen mice" setting,
+  harder than the dependent base model (which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice; test = **90 held-out sessions** from 22 mice (WT 79% / HT 21%).
+- **What was adapted vs the base model (lever E — focal loss):** loss is **focal** (`focal_gamma=2.0`)
+  with **no** class weighting (`pos_weight_beta=0.0`, no sampler), intended to refocus learning on the
+  hard minority class. Plus two levers change together: model family (BiLSTM instead of XGBoost) **and**
+  evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.786 | 0.167 | — |
+| Recall | 0.930 | 0.053 | — |
+| F1 | 0.852 | 0.080 | weighted **0.689** |
+| Accuracy | | | **0.744** (train 0.819) |
+
+Test AUC 0.640 · balanced accuracy 0.491 · MCC −0.029 · PR-AUC 0.284. Best val AUC 0.817; early stopped
+at epoch 27. Confusion matrix (rows = true, cols = pred): `[[WT→WT 66, WT→HT 5], [HT→WT 18, HT→HT 1]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.744 | 0.733 | +0.011 |
+| Weighted F1 | 0.689 | 0.749 | −0.060 |
+| WT F1 | 0.852 | 0.785 | +0.067 |
+| HT F1 | 0.080 | 0.649 | −0.569 |
+| HT recall | 0.053 | 0.940 | −0.887 |
+| HT precision | 0.167 | 0.496 | −0.329 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 90 session-level sequences, while
+the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse toward WT.** HT recall is **0.053** (1 of 19 HT sessions caught) and HT F1 is
+  **0.080** — the model predicts WT for almost everyone. Balanced accuracy 0.491 and MCC −0.029 are at
+  chance/slightly-negative, so the headline 0.744 accuracy is just the WT majority rate (79%).
+- **Focal loss did not rescue the minority class.** With no class weighting and no sampler
+  (`pos_weight_beta=0.0`), focal `gamma=2.0` on this tiny 238-session train set (HT 24%) left the model
+  unable to learn HT — the exact failure focal loss was meant to prevent here.
+- **The model can rank but not decide.** Best val AUC reached 0.817 and test AUC is 0.640, yet at the
+  default 0.5 cut almost nothing crosses into HT — a threshold/calibration problem on top of the
+  collapse. Train 0.819 vs test 0.744 also shows overfitting on so few sessions.
+- Versus the base, accuracy and WT F1 nudge up only because the base trades WT recall for HT recall
+  (HT recall 0.940); this run does the opposite and loses essentially all minority-class signal.
+
+## Recommendations
+- Prefer the class-balancing levers for this split: the **D balanced minibatch sampler** is the most
+  reliable fix for collapse here; focal loss alone is not sufficient.
+- If keeping focal loss, re-introduce class weighting (`pos_weight_beta>0`) or a sampler, and tune the
+  decision threshold (AUC 0.64–0.82 suggests usable ranking the 0.5 cut throws away).
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.640). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/bilstm_best.pt` — best-checkpoint weights. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`. `logs/out.txt` — flags, split info, class balance, early stopping.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/F_regsmall__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/F_regsmall__bilstm__dependent/README.md
@@ -1,0 +1,65 @@
+# F_regsmall__bilstm__dependent — BiLSTM · subject-dependent · experiment F (regsmall)
+
+> Heavily-regularized small BiLSTM on the baseline sequences, dependent split — collapses to near-all-WT.
+
+## Overview
+- **Model:** BiLSTM over chronological per-syllable sequences (order preserved), scored at session level
+  — not the 48 aggregated per-recording features the tabular base uses. This is the **regsmall**
+  variant: shrunk to `hidden_size=32`, `num_layers=1` with `weight_decay=0.001` and `dropout=0.5`
+  (16,857 params, far below the ~149K full BiLSTM).
+- **Evaluation split:** subject-**dependent** — random session-level split, so the same mouse can sit in
+  train and test (logged overlap: 61 shared mice train/test). Optimistic/leaky, same family as the base.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice; 244 train / 82 val / 82 test sessions (test HT 23% / WT 77%).
+- **What was adapted vs the base model:** lever **F (regsmall)** — extra regularization + a smaller net
+  intended to curb overfitting on the tiny independent split, here run on the dependent split. Mild
+  class weighting carried in (`pos_weight_beta=0.5`, `pos_weight≈1.79`, BCE loss, no sampler).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.778 | 1.000 | — |
+| Recall | 1.000 | 0.053 | — |
+| F1 | 0.875 | 0.100 | weighted **0.695** |
+| Accuracy | | | **0.780** (train 0.762) |
+
+AUC 0.683 · balanced accuracy 0.526 · MCC 0.202 · PR-AUC 0.426 · early-stopped at epoch 24 (best val AUC 0.720).
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 63, WT→HT 0], [HT→WT 18, HT→HT 1]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.780 | 0.733 | +0.047 |
+| Weighted F1 | 0.695 | 0.749 | −0.054 |
+| WT F1 | 0.875 | 0.785 | +0.090 |
+| HT F1 | 0.100 | 0.649 | −0.549 |
+| HT recall | 0.053 | 0.940 | −0.887 |
+| HT precision | 1.000 | 0.496 | +0.504 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, whereas the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse toward WT.** The net predicts WT for 81 of 82 sessions: WT recall 1.000, HT
+  recall 0.053 (1 of 19 HT sessions caught), HT F1 just 0.100. The headline 0.780 accuracy is the
+  majority-class baseline (test WT share 77%), not real learning.
+- **Balanced accuracy 0.526 and MCC 0.202** confirm the model barely separates classes — the +0.047
+  accuracy and +0.504 HT precision over base are artifacts of the all-WT operating point (the single HT
+  call happens to be correct), while HT recall craters −0.887.
+- **Over-regularization, wrong split.** regsmall was designed for the small leak-free independent split;
+  applied to the dependent split it just suppresses the minority class. Val AUC peaked at 0.720 (epoch 9)
+  then drifted down — the small net never found a usable HT decision region at the 0.5 cut.
+
+## Recommendations
+- Do not use this run as a dependent reference — it is a collapsed model. The base XGBoost dependent run
+  (HT recall 0.940) is the comparison anchor.
+- For BiLSTM collapse, the balanced-minibatch sampler (lever **D**) is the most reliable fix; pair with a
+  lower decision threshold (see threshold runs) rather than stacking weight decay + dropout + shrinkage.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.683). `plots/training_curves.png` — loss/accuracy/AUC over 24 epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` (classification_report, config) + `logs/out.txt` (split info, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/F_regsmall__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/F_regsmall__bilstm__independent/README.md
@@ -1,0 +1,68 @@
+# F_regsmall__bilstm__independent — BiLSTM · subject-independent · experiment F (regsmall)
+
+> Heavily regularized, downsized BiLSTM on baseline sequence data, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** BiLSTM over chronological per-syllable sequences (order preserved), scored at **session
+  level** — unlike the tabular base, which uses 48 aggregated per-recording features. Shrunk for the
+  tiny independent split: `hidden_size=32`, `num_layers=1`, only **16,857 params** (the full BiLSTM is
+  ~149K). Trained 35 epochs (early-stopped, best val AUC 0.811).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice. Test = **90 held-out sessions** from 22 mice (WT 79% / HT 21%).
+- **What was adapted vs the base model:** lever **F (regsmall)** — weight decay (`0.001`) + high dropout
+  (`0.5`) + a smaller net, plus milder class weighting (`pos_weight_beta=0.5`, pos_weight 1.80). Two
+  things change together: model family (BiLSTM instead of XGBoost) **and** dependent → independent eval.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.812 | 0.286 | — |
+| Recall | 0.789 | 0.316 | — |
+| F1 | 0.800 | 0.300 | weighted **0.694** |
+| Accuracy | | | **0.689** (train 0.840) |
+
+Test AUC 0.701 · balanced acc 0.552 · MCC 0.101 · PR-AUC 0.356.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 56, WT→HT 15], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.689 | 0.733 | −0.044 |
+| Weighted F1 | 0.694 | 0.749 | −0.055 |
+| WT F1 | 0.800 | 0.785 | +0.015 |
+| HT F1 | 0.300 | 0.649 | −0.349 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.286 | 0.496 | −0.210 |
+
+*Directional only, not like-for-like: this NN is scored on 90 session-level sequences, while the
+tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- Regularization avoids the usual degenerate collapse — both classes get predicted (HT recall 0.316,
+  WT recall 0.789, no all-one-class output) — but the minority class is barely learned: **HT F1 0.300**,
+  HT precision 0.286, MCC 0.101 and balanced accuracy 0.552 are only just above chance.
+- The minority class craters versus the dependent base: **HT recall −0.624** and **HT F1 −0.349**.
+  Only 6 of 19 HT sessions are caught; 13 are missed as WT. Headline accuracy (0.689) holds up only
+  because the test set is 79% WT and WT is predicted well (F1 0.800).
+- Val AUC peaked at 0.811 (epoch 20) but **test AUC is 0.701** — a ~0.11 generalization gap on truly
+  unseen mice, with train acc 0.840 vs test 0.689 confirming the split is the hard part, not capacity.
+- The tiny independent split (238 train / 80 val / 90 test sessions; only 56 HT train sessions) leaves
+  too little minority signal for a sequence model to separate the classes reliably.
+
+## Recommendations
+- For a sequence model on this independent split, prefer the balanced-sampler line (lever **D /
+  cv_Dsampler**), which is the most reliable fix for minority under-prediction; regsmall alone is not
+  enough here.
+- At the default 0.5 cut HT recall is unusable (0.316); if this run is kept, threshold tuning toward a
+  `target_recall` operating point is required before any "new-mouse" use.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.701). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/F_regsmall__cnn1d__dependent/README.md
+++ b/results/neural_networks/experiments/F_regsmall__cnn1d__dependent/README.md
@@ -1,0 +1,60 @@
+# F_regsmall__cnn1d__dependent — 1D-CNN · subject-dependent · experiment F (regsmall)
+
+> A regularized, shrunk 1D-CNN on the baseline sequence data, scored on the optimistic (leaky) dependent split.
+
+## Overview
+- **Model:** 1D-CNN over a chronological per-syllable sequence (order preserved; `max_seq_len=256`),
+  86,041 params. Scored at **session level** (82 test sessions), not recording level.
+- **Evaluation split:** subject-dependent — random session-level split (`group_split=false`), so the same
+  mouse appears in train, val and test. The log confirms leakage: **61 shared mice train/test**, 56 train/val.
+  This is the optimistic setting (no mouse-level isolation).
+- **Dataset:** official baseline sequence cache (Issue #46 filters; April-2026 HET→WT correction).
+  408 sessions / 106 mice → train 244 · val 82 · test 82; test balance HT 23% / WT 77%.
+- **What was adapted vs the base model:** experiment **F regsmall** — heavy regularization for a tiny split:
+  `weight_decay=0.001`, `dropout=0.5`, shrunk net (`hidden_size=32`, `num_layers=1`), with mild class
+  weighting (`pos_weight_beta=0.5` → pos_weight 1.791, BCE loss). Trained on sequences instead of the
+  base model's 48 aggregated tabular features.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.774 | 0.250 | — |
+| Recall | 0.762 | 0.263 | — |
+| F1 | 0.768 | 0.256 | weighted **0.649** |
+| Accuracy | | | **0.646** (train 0.803) |
+
+AUC 0.588 · balanced acc 0.513 · macro-F1 0.512 · MCC 0.025. Best val AUC 0.710, early-stopped at epoch 22.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 48, WT→HT 15], [HT→WT 14, HT→HT 5]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.646 | 0.733 | −0.087 |
+| Weighted F1 | 0.649 | 0.749 | −0.100 |
+| WT F1 | 0.768 | 0.785 | −0.017 |
+| HT F1 | 0.256 | 0.649 | −0.393 |
+| HT recall | 0.263 | 0.940 | −0.677 |
+| HT precision | 0.250 | 0.496 | −0.246 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, while the
+tabular base model is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **No collapse, but no signal either.** The regsmall recipe avoids the usual degenerate all-HT/all-WT
+  failure (HT recall 0.263, WT recall 0.762, both classes predicted), yet **MCC 0.025 and AUC 0.588** show
+  the model is barely above chance — predictions track class priors more than genotype.
+- **The minority class is essentially missed:** HT F1 0.256 (−0.393 vs base) with precision 0.250 — 3 of
+  every 4 HT calls are wrong, and only 5 of 19 true HT sessions are caught.
+- **Heavy regularization did not buy generalization.** Even on the leaky dependent split, test acc 0.646
+  trails train acc 0.803 (0.16 gap) and the base model's 0.733; val AUC peaked at 0.710 by epoch 7 then
+  decayed, suggesting the tiny 244-session sequence set offers little for the CNN to learn.
+- Sequence-level NN on this dependent split underperforms the aggregated-feature tabular base across every
+  metric, most severely on minority-class recovery.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.588). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint (val AUC). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/F_regsmall__cnn1d__independent/README.md
+++ b/results/neural_networks/experiments/F_regsmall__cnn1d__independent/README.md
@@ -1,0 +1,71 @@
+# F_regsmall__cnn1d__independent — 1D-CNN · subject-independent · experiment F (regsmall)
+
+> Regularized, shrunk 1D-CNN for the tiny leak-free split — no collapse, but the minority class is barely learned.
+
+## Overview
+- **Model:** 1D-CNN over chronological per-syllable sequences (86,041 params; `max_seq_len=256`).
+  Input is the order-preserved syllable stream, not the 48 aggregated per-recording tabular features;
+  scoring is at **session level** (90 test sessions), not recording level.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware), so no mouse appears in two sets. Honest "generalize to unseen mice" setting (harder than
+  the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice → Train 238 (63 mice, HT 24%), Val 80 (21 mice, HT 28%), Test 90 (22 mice, **HT 21% / WT 79%**).
+- **What was adapted vs the base model:** experiment **F = regsmall** — anti-overfit recipe sized for the
+  tiny independent split: weight decay 0.001 + dropout 0.5 + a smaller net (`hidden_size=32`,
+  `num_layers=1`), with mild class weighting (`pos_weight_beta=0.5` → pos_weight 1.803, BCE loss, no
+  sampler). Two levers move together vs base: model family (1D-CNN instead of XGBoost) **and** dependent →
+  independent evaluation.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.833 | 0.389 | — |
+| Recall | 0.845 | 0.368 | — |
+| F1 | 0.839 | 0.378 | weighted **0.742** |
+| Accuracy | | | **0.744** (train 0.782) |
+
+Other test metrics: AUC-ROC 0.539, balanced accuracy 0.607, PR-AUC 0.335, MCC 0.218; best val AUC 0.760.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 60, WT→HT 11], [HT→WT 12, HT→HT 7]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.744 | 0.733 | +0.011 |
+| Weighted F1 | 0.742 | 0.749 | −0.007 |
+| WT F1 | 0.839 | 0.785 | +0.054 |
+| HT F1 | 0.378 | 0.649 | −0.271 |
+| HT recall | 0.368 | 0.940 | −0.572 |
+| HT precision | 0.389 | 0.496 | −0.107 |
+
+*Directional comparison only: this NN is scored on 90 session-level sequences, while the tabular base is
+scored on ~2,465 recording-level rows — not a like-for-like benchmark.*
+
+## Key insights
+- **No degenerate collapse** — both classes get predicted (WT recall 0.845, HT recall 0.368), so the
+  regsmall recipe avoids the all-HT / all-WT failure that plagues the independent split. But the win is
+  shallow: it mostly classifies WT well and treats HT as noise.
+- **The minority class is barely learned.** HT recall 0.368 and HT F1 0.378 mean the model catches only
+  7 of 19 ASD-model sessions and is wrong on more HT calls than it gets right (precision 0.389). The
+  headline accuracy 0.744 is essentially the WT base rate (79%) lightly beaten.
+- **Test AUC 0.539 ≈ chance**, far below best val AUC 0.760 — the ranking learned on validation mice does
+  not transfer to held-out test mice. Class weighting is so mild here that the operating point sits near
+  the majority class; balanced accuracy 0.607 / MCC 0.218 confirm weak-but-real signal.
+- Train 0.782 vs test 0.744 is a small gap (regularization worked), and early stopping fired at epoch 22
+  — so the failure is generalization of the *signal*, not overfitting; the independent split simply has
+  too few HT examples (56 train / 19 test sessions) for this sequence model.
+
+## Recommendations
+- The mild `pos_weight_beta=0.5` is too weak here — compare against the **D balanced-sampler** config
+  (the most reliable anti-collapse fix) and **H cv_Dsampler** to see if HT recall can be raised without
+  re-triggering collapse.
+- For any "new-mouse" estimate, prefer the tabular independent runs over this NN: at AUC ≈ chance and
+  HT F1 0.378, this 1D-CNN is not yet usable for ASD-model detection on unseen mice.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.539). `plots/training_curves.png` — train/val loss, acc, AUC vs epoch.
+- `model/cnn1d_best.pt` — best checkpoint (epoch with val AUC 0.760). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/F_regsmall__transformer__dependent/README.md
+++ b/results/neural_networks/experiments/F_regsmall__transformer__dependent/README.md
@@ -1,0 +1,67 @@
+# F_regsmall__transformer__dependent — Transformer · subject-dependent · experiment F (regsmall)
+
+> Heavily-regularized small Transformer on per-syllable sequences, evaluated on the optimistic (leaky) session-level split.
+
+## Overview
+- **Model:** Transformer (sequence classifier over the chronological per-syllable feature sequence;
+  order preserved). 39,065 params — smaller than the ~73K default; `d_model=64`, `hidden_size=32`,
+  1 layer.
+- **Evaluation split:** subject-dependent — random **session-level** split (`subject_eval_independent=false`,
+  `group_split=false`). Same mouse can land in train and test (the log warns of 61 shared train/test
+  mice), so this is the optimistic, leakage-prone setting.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice; split 244 train / 82 val / 82 test sessions. Test class balance: WT 63 (77%) / HT 19 (23%).
+- **What was adapted vs the base model (lever F = regsmall):** anti-collapse regularization for the tiny
+  split — `weight_decay=0.001`, `dropout=0.5`, shrunken net (`hidden_size=32`, `num_layers=1`), plus
+  mild class weighting (`pos_weight_beta=0.5`, BCE loss, no sampler). Model family also moves from
+  XGBoost to a Transformer over sequences.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.776 | 0.333 | — |
+| Recall | 0.937 | 0.105 | — |
+| F1 | 0.849 | 0.160 | weighted **0.689** |
+| Accuracy | | | **0.744** (train 0.840) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 59, WT→HT 4], [HT→WT 17, HT→HT 2]]`.
+Test AUC-ROC 0.773 · balanced accuracy 0.521 · MCC 0.068 · best val AUC 0.794 · early-stopped at epoch 92/100.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.744 | 0.733 | +0.011 |
+| Weighted F1 | 0.689 | 0.749 | −0.060 |
+| WT F1 | 0.849 | 0.785 | +0.064 |
+| HT F1 | 0.160 | 0.649 | −0.489 |
+| HT recall | 0.105 | 0.940 | −0.835 |
+| HT precision | 0.333 | 0.496 | −0.163 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 82 session-level sequences, while the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Near-total WT collapse on the minority class.** HT recall is 0.105 — only 2 of 19 ASD-model pups
+  are caught, 17 are called WT — and HT F1 is 0.160. The headline accuracy 0.744 is almost entirely the
+  majority-class score (WT recall 0.937); it barely beats the 0.77 always-WT rate.
+- Balanced accuracy 0.521 and MCC 0.068 confirm the model is doing little better than constant-WT
+  prediction, even though ranking is non-trivial (test AUC 0.773). The threshold, not the scores, is the
+  problem.
+- The `regsmall` regularization did **not** prevent collapse here. Mild `pos_weight_beta=0.5` (pos_weight
+  1.79) was too weak against the 24% HT base rate; the heavy dropout/weight-decay capped capacity without
+  fixing the operating point.
+- The +0.011 accuracy and +0.064 WT F1 over base are mirages from the leaky dependent split and the
+  collapse toward WT — the −0.489 HT F1 / −0.835 HT recall are the real story.
+
+## Recommendations
+- This config is not deployable: at the default 0.5 cut it misses ~9 in 10 ASD-model pups. Because AUC is
+  healthy (0.773), a lower decision threshold or stronger class weighting/sampler would recover HT recall.
+  The balanced-minibatch sampler (lever D) is the more reliable anti-collapse fix than `regsmall` on this
+  tiny split.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.773). `plots/training_curves.png` — loss/acc/AUC over 92 epochs.
+- `model/transformer_best.pt` — best checkpoint (by val AUC). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split/data stats and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/F_regsmall__transformer__independent/README.md
+++ b/results/neural_networks/experiments/F_regsmall__transformer__independent/README.md
@@ -1,0 +1,69 @@
+# F_regsmall__transformer__independent — Transformer · subject-independent · experiment F (regsmall)
+
+> Heavily-regularized small Transformer on session-level sequences, leak-free split — **collapses to predicting WT for everyone**.
+
+## Overview
+- **Model:** Transformer (~39K params; `d_model` 64, `hidden_size` 32, 1 layer). Input is a chronological
+  per-syllable sequence (order preserved, `max_seq_len` 256), scored at **session level**, unlike the
+  tabular base's 48 aggregated per-recording features.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent` /
+  group-aware), so no mouse appears in two sets. Honest "generalize to unseen mice" setting, harder than
+  the dependent base model (random row split, mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106 mice
+  → Train 238 (63 mice, HT 24%) · Val 80 (21 mice, HT 28%) · **Test 90 sessions (22 mice, HT 21% / WT 79%)**.
+- **What was adapted vs the base model:** lever **F regsmall** — weight decay (`1e-3`) + high dropout (0.5)
+  + a smaller net, intended to fight overfitting on the tiny independent split. Mild class weighting kept
+  (`pos_weight_beta=0.5`, `pos_weight=1.803`, BCE loss, no sampler). Two things change together vs base:
+  model family (Transformer instead of XGBoost) **and** dependent → independent evaluation.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.789 | 0.000 | — |
+| Recall | 1.000 | 0.000 | — |
+| F1 | 0.882 | 0.000 | weighted **0.696** |
+| Accuracy | | | **0.789** (train 0.765) |
+
+AUC-ROC 0.815 · PR-AUC 0.616 · balanced accuracy **0.500** · MCC **0.000** · macro-F1 0.441.
+Best val AUC 0.868, early-stopped at epoch 23/100.
+
+Confusion (rows = true, cols = pred): `[[WT→WT 71, WT→HT 0], [HT→WT 19, HT→HT 0]]` — **every session predicted WT**.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.789 | 0.733 | +0.056 |
+| Weighted F1 | 0.696 | 0.749 | −0.053 |
+| WT F1 | 0.882 | 0.785 | +0.097 |
+| HT F1 | 0.000 | 0.649 | −0.649 |
+| HT recall | 0.000 | 0.940 | −0.940 |
+| HT precision | 0.000 | 0.496 | −0.496 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 90 session-level sequences, while the tabular base is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Degenerate collapse: predicts WT for all 90 test sessions** (HT recall 0.000, HT F1 0.000, WT recall
+  1.000). The 0.789 "accuracy" and +0.056 vs base are an artifact of the 79% WT majority — balanced
+  accuracy 0.500 and MCC 0.000 confirm the model has zero discriminative output at the 0.5 cut.
+- **The ranking is not random — the threshold is.** Test AUC-ROC 0.815 / PR-AUC 0.616 (and best val AUC
+  0.868) mean the logits *do* separate classes, but the decision boundary sits above every HT score, so
+  all positives are missed. This is a thresholding/calibration failure, not a no-signal failure.
+- **The regsmall lever over-corrected.** Aggressive regularization (dropout 0.5, weight decay 1e-3,
+  tiny net) plus only mild class weighting (`beta=0.5`) pushed the model to the safe majority prediction;
+  train accuracy 0.765 ≈ the 76% WT train prior, so it never actually learned the minority class.
+
+## Recommendations
+- Do not use this run as-is — at the default 0.5 cut it detects no ASD-model pups. Since AUC ≈ 0.82, a
+  recall-targeted threshold (e.g. `target_recall` ~0.80) on the validation set would likely recover usable
+  HT detection from the same logits.
+- For fixing the collapse at train time, prefer the **D balanced-sampler** config (most reliable
+  anti-collapse fix in this study) over the regsmall recipe, or pair regsmall with stronger class
+  weighting (`beta=0`) / focal loss rather than `beta=0.5`.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (all-WT column).
+- `plots/roc_curve.png` — ROC (AUC 0.815). `plots/training_curves.png` — loss/acc/AUC vs epoch.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/G_augment__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/G_augment__bilstm__dependent/README.md
@@ -1,0 +1,65 @@
+# G_augment__bilstm__dependent — BiLSTM · subject-dependent · experiment G (augment)
+
+> BiLSTM on the baseline sequence data with sliding-window augmentation, evaluated on the leaky (mouse-overlap) dependent split.
+
+## Overview
+- **Model:** BiLSTM (~149K params; 2 layers, hidden 64, dropout 0.3) over a chronological per-syllable
+  sequence (`max_seq_len` 256, order preserved), scored at **session** level — not the 48 aggregated
+  per-recording tabular features of the base model.
+- **Evaluation split:** subject-dependent — random session-level split (`subject_eval_independent=false`,
+  `group_split=false`). The log flags **mouse overlap** (train/test 61 shared mice), so the same pup can
+  appear in train and test (leakage; optimistic vs an honest by-mouse split).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice → train 244 / val 82 / **test 82** sessions (HT 23%, WT 77%).
+- **What was adapted vs the base model (lever G):** sliding-window augmentation (`augment_windows=4`,
+  `window_stride=128`) expanding 244 sessions into 369 train windows, on top of mild class weighting
+  (`pos_weight_beta=0.5` → pos_weight 1.791); plain BCE, no sampler, no weight decay.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.800 | 0.353 | — |
+| Recall | 0.825 | 0.316 | — |
+| F1 | 0.813 | 0.333 | weighted **0.701** |
+| Accuracy | | | **0.707** (train 0.791) |
+
+AUC 0.673 · balanced accuracy 0.571 · MCC 0.147 · PR-AUC 0.378 · best val AUC 0.748 · early-stopped at epoch 28/100.
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 52, WT→HT 11], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.707 | 0.733 | −0.026 |
+| Weighted F1 | 0.701 | 0.749 | −0.048 |
+| WT F1 | 0.813 | 0.785 | +0.028 |
+| HT F1 | 0.333 | 0.649 | −0.316 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.353 | 0.496 | −0.143 |
+
+*Directional only: this BiLSTM is scored on 82 session-level sequences, whereas the tabular base is scored on ~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- The minority class is badly under-served, the **opposite** of the usual NN collapse: HT recall **0.316**
+  and HT F1 **0.333** mean the model only catches 6 of 19 ASD-model pups and leans toward calling WT.
+  HT recall is −0.624 below the base model — augmentation did not rescue the positive class here.
+- Headline accuracy (0.707) sits near the WT prior (77%); balanced accuracy 0.571 and MCC 0.147 confirm
+  the model is barely above chance once class imbalance is accounted for.
+- Overfitting is visible despite augmentation: train accuracy climbs to ~0.91 while val loss rises after
+  ~epoch 13 (val AUC peaks 0.748, then drifts down), triggering early stopping at 28. Test AUC is only
+  0.673, below best val AUC.
+- WT metrics improved (+0.028 F1) only because predictions shifted toward the majority class — that gain
+  is the flip side of the HT collapse, not a real win.
+
+## Recommendations
+- For collapse toward WT, the balanced minibatch sampler (lever D) is the most reliable fix in this
+  brief; mild `pos_weight_beta=0.5` plus window augmentation was insufficient. If keeping this config,
+  threshold tuning on the HT score is needed to recover usable HT recall.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.673). `plots/training_curves.png` — loss/accuracy/AUC per epoch.
+- `model/bilstm_best.pt` — best checkpoint (val AUC 0.748). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split/data/training trace: `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/G_augment__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/G_augment__bilstm__independent/README.md
@@ -1,0 +1,70 @@
+# G_augment__bilstm__independent — BiLSTM · subject-independent · sliding-window augmentation
+
+> BiLSTM on the leak-free split with sliding-window sequence augmentation; does not recover the minority class.
+
+## Overview
+- **Model:** BiLSTM (2-layer bidirectional LSTM, hidden 64, dropout 0.3; 148,953 params). Input is the
+  chronological per-syllable sequence (order preserved, capped at `max_seq_len=256`), not the 48
+  aggregated per-recording tabular features.
+- **Evaluation split:** subject-independent — group-aware train/val/test split **by mouse**
+  (`--independent`), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting, harder than the dependent base model (which splits rows randomly and lets mice leak).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions / 106
+  mice → Train 238 (63 mice, HT 24%), Val 80 (21 mice, HT 28%), Test 90 sessions from 22 held-out mice
+  (WT 79% / HT 21%). Scoring is **session-level**, not recording-level.
+- **What was adapted vs the base model:** lever **G — sliding-window augmentation** (`augment_windows=4`,
+  `window_stride=128`, yielding 367 train windows from 238 sessions), kept on top of mild class weighting
+  (`pos_weight_beta=0.5` → pos_weight 1.803), BCE loss, no sampler. Plus the model family (BiLSTM) and
+  the dependent → independent evaluation change together.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.831 | 0.290 | — |
+| Recall | 0.690 | 0.474 | — |
+| F1 | 0.754 | 0.360 | weighted **0.671** |
+| Accuracy | | | **0.644** (train 0.777) |
+
+Test AUC 0.581 · balanced acc 0.582 · macro-F1 0.557 · MCC 0.141 · PR-AUC 0.297. Best val AUC 0.833
+(epoch 10); early stopping at epoch 25.
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 49, WT→HT 22], [HT→WT 10, HT→HT 9]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.644 | 0.733 | −0.089 |
+| Weighted F1 | 0.671 | 0.749 | −0.078 |
+| WT F1 | 0.754 | 0.785 | −0.031 |
+| HT F1 | 0.360 | 0.649 | −0.289 |
+| HT recall | 0.474 | 0.940 | −0.466 |
+| HT precision | 0.290 | 0.496 | −0.206 |
+
+*Comparison is directional, not like-for-like: this NN is scored on 90 session-level sequences from 22
+held-out mice, whereas the tabular base is scored on ~2,465 recording-level rows from a leaky dependent
+split.*
+
+## Key insights
+- The minority class is the weak point: **HT precision 0.290 and HT recall 0.474** — the model catches
+  fewer than half the ASD-model pups and is wrong on ~7 of every 10 positive calls (9 of 19 HT correct,
+  10 missed). Not a degenerate collapse (both classes get predicted), but well below useful.
+- **Augmentation did not buy generalization.** Val AUC peaked at 0.833 (epoch 10) then the model
+  overfit — train acc climbed to 0.94 while val loss rose to ~1.1 — and **test AUC collapsed to 0.581**,
+  barely above chance. The 0.777 train vs 0.644 test gap confirms overfitting on the tiny 238-session
+  independent split that augmentation does not cure.
+- Every headline metric trails the base model (HT F1 −0.289, HT recall −0.466), but recall the caveat:
+  this is the honest leak-free, session-level setting versus the optimistic leaky recording-level base.
+- MCC 0.141 and balanced acc 0.582 show only marginal class separation overall.
+
+## Recommendations
+- On this tiny independent split the balanced minibatch sampler (lever D) is the more reliable fix for
+  minority-class weakness than window augmentation; prefer it over G here.
+- Use early-stopping on val AUC at the epoch-10 peak (0.833) rather than letting training run to 25 —
+  the held-out test AUC of 0.581 suggests the late-epoch checkpoint generalizes poorly.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — normalized and count confusion
+  matrices. `plots/roc_curve.png` — test ROC. `plots/training_curves.png` — loss/acc/AUC over epochs.
+- `model/bilstm_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split info, class balance and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/G_augment__cnn1d__dependent/README.md
+++ b/results/neural_networks/experiments/G_augment__cnn1d__dependent/README.md
@@ -1,0 +1,65 @@
+# G_augment__cnn1d__dependent — 1D-CNN · subject-dependent · sliding-window augmentation
+
+> 1D-CNN on the baseline sequence data with sliding-window augmentation; evaluated subject-dependent (leaky) — collapses toward predicting WT for almost everyone.
+
+## Overview
+- **Model:** 1D-CNN (~86K params; chronological per-syllable sequence input, order preserved,
+  `max_seq_len=256`). Scored at **session level** (82 test sessions), not per recording.
+- **Evaluation split:** subject-dependent — random session-level split (`subject_eval_independent=false`,
+  `group_split=false`). Mice leak across sets (log: 61 shared mice train/test), so this is the
+  optimistic setting, like the base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions /
+  106 mice; train 244 / val 82 / test 82, HT ≈ 23–24% throughout.
+- **What was adapted vs the base model (lever G):** sliding-window augmentation
+  (`augment_windows=4`, `window_stride=128` → 369 train windows from 244 sessions), on top of milder
+  class weighting (`pos_weight_beta=0.5` → pos_weight 1.79, BCE loss, no sampler).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.776 | 0.333 | — |
+| Recall | 0.937 | 0.105 | — |
+| F1 | 0.849 | 0.160 | weighted **0.689** |
+| Accuracy | | | **0.744** (train 0.832) |
+
+AUC 0.587 · balanced acc 0.521 · macro F1 0.504 · MCC 0.068 · PR-AUC 0.331. Early-stopped at epoch 24
+(best val AUC 0.702). Confusion matrix (rows = true): `[[WT→WT 59, WT→HT 4], [HT→WT 17, HT→HT 2]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.744 | 0.733 | +0.011 |
+| Weighted F1 | 0.689 | 0.749 | −0.060 |
+| WT F1 | 0.849 | 0.785 | +0.064 |
+| HT F1 | 0.160 | 0.649 | −0.489 |
+| HT recall | 0.105 | 0.940 | −0.835 |
+| HT precision | 0.333 | 0.496 | −0.163 |
+
+*Directional only: this NN is scored on ~82 session-level sequences, whereas the tabular base is scored
+on ~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- **Degenerate collapse toward WT.** The model calls HT for only 2 of 19 positives (HT recall 0.105,
+  HT F1 0.160); the +0.011 accuracy bump is purely from the 77% WT majority. Despite augmentation and
+  pos_weight 1.79, it learned to predict WT for almost everyone.
+- **No real discrimination.** Test AUC 0.587, balanced accuracy 0.521 and MCC 0.068 are barely above
+  chance — the headline 0.744 accuracy is misleading.
+- **Train/val divergence.** Train accuracy climbs to 0.93 while val loss rises after ~epoch 10 (val AUC
+  plateaus ~0.70); the model overfits the WT majority rather than learning HT structure, and the gap
+  carries straight into the collapsed test result.
+- Augmentation (369 windows) did not rescue the minority class on this leaky split — it mostly
+  reinforced the WT prior.
+
+## Recommendations
+- Prefer the balanced-minibatch sampler config (lever D / H) over augmentation for collapse; pos_weight
+  alone (lever G here) is insufficient on this data.
+- Do not use this run for any HT-detection claim — HT recall 0.105 means it misses ~9 in 10 ASD-model
+  pups. If kept, threshold tuning toward `target_recall` is mandatory before use.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.587). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json`; split info, data stats and early stopping in `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/G_augment__cnn1d__independent/README.md
+++ b/results/neural_networks/experiments/G_augment__cnn1d__independent/README.md
@@ -1,0 +1,71 @@
+# G_augment__cnn1d__independent — 1D-CNN · subject-independent · experiment G (augment)
+
+> 1D-CNN on chronological per-syllable sequences, leak-free split, with sliding-window augmentation — degenerates to near-chance on the tiny held-out test set.
+
+## Overview
+- **Model:** 1D-CNN (~86K params) over a chronological per-syllable sequence (`max_seq_len=256`,
+  order preserved), scored at the **session** level — not the 48 aggregated per-recording features the
+  tabular base model uses.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  `group_split`), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak across
+  train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Train 238 sessions (63 mice, HT 24%), val 80 (21 mice), test **90 sessions
+  from 22 held-out mice** (HT 19 / WT 71, i.e. 21% HT).
+- **What was adapted vs the base model (lever G):** sliding-window augmentation
+  (`augment_windows=4`, `window_stride=128` → 367 train windows from 238 sessions) layered on the
+  config-B class weighting (`pos_weight_beta=0.5` → `pos_weight=1.803`, BCE loss, `sampler=none`).
+  Two things move at once vs base: model family (1D-CNN instead of XGBoost) **and** dependent →
+  independent evaluation. Trained 39/100 epochs (early stopped, best val AUC 0.783).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.776 | 0.188 | — |
+| Recall | 0.634 | 0.316 | — |
+| F1 | 0.698 | 0.235 | weighted **0.600** |
+| Accuracy | | | **0.567** (train 0.924) |
+
+Test AUC 0.449 · balanced acc 0.475 · PR-AUC 0.210 · MCC **−0.043** (below random).
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 45, WT→HT 26], [HT→WT 13, HT→HT 6]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.567 | 0.733 | −0.166 |
+| Weighted F1 | 0.600 | 0.749 | −0.149 |
+| WT F1 | 0.698 | 0.785 | −0.087 |
+| HT F1 | 0.235 | 0.649 | −0.414 |
+| HT recall | 0.316 | 0.940 | −0.624 |
+| HT precision | 0.188 | 0.496 | −0.308 |
+
+*Directional only, not like-for-like: this NN is scored on 90 session-level sequences, whereas the
+tabular base model is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **The model fails to generalize.** Test AUC 0.449 and MCC −0.043 are at/below chance — the learned
+  scores carry essentially no signal on unseen mice, despite a healthy val AUC (0.783). Train accuracy
+  0.924 vs test 0.567 is a ~0.36 gap: the augmented CNN overfit the 63 train mice.
+- **Minority class barely detected, not collapsed.** Unlike the usual degenerate failure (HT recall
+  ~1.0 or HT F1 0), here HT recall is only **0.316** (6 of 19 HT sessions caught) at precision **0.188**
+  — both classes are predicted, but HT calls are wrong ~4 times out of 5 (HT F1 0.235).
+- **Sliding-window augmentation did not help.** Adding 4 windows/session (367 windows) on top of the
+  mild B weighting produced the weakest minority-class result of the lever set; the extra views appear
+  to amplify train-mouse memorization rather than improve robustness to new mice.
+- Held-out test is tiny (90 sessions, 19 HT) — single-split estimates here are high-variance; see the
+  H `cv_Dsampler` cross-validation run for a more stable read.
+
+## Recommendations
+- Do not use this run for any new-mouse performance estimate — AUC < 0.5 means it underperforms a coin
+  flip on ranking. Prefer the D (balanced sampler) family or the tabular independent runs.
+- If 1D-CNN is kept on the independent split, drop augmentation and try the balanced minibatch sampler
+  (lever D) and/or `regsmall` (lever F) to fight the train-mouse overfit before retuning class weights.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.449). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/cnn1d_best.pt` — best checkpoint (val AUC 0.783). `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/H_cv_Dsampler__bilstm__dependent/README.md
+++ b/results/neural_networks/experiments/H_cv_Dsampler__bilstm__dependent/README.md
@@ -1,0 +1,69 @@
+# H_cv_Dsampler__bilstm__dependent — BiLSTM · subject-dependent · 5-fold CV (D-sampler config)
+
+> BiLSTM over per-syllable sequences, 5-fold cross-validation of the balanced-sampler (D) config, evaluated subject-**dependent** (sessions split randomly, mice may leak).
+
+## Overview
+- **Model:** BiLSTM (~149K params; `hidden_size=64`, `num_layers=2`, `dropout=0.3`). Input is a
+  chronological per-syllable sequence (order preserved, `max_seq_len=256`), unlike the tabular base
+  model's 48 aggregated per-recording features. Scored at **session level**, not recording level.
+- **Evaluation split:** subject-dependent — sessions split randomly (`subject_eval_independent=false`,
+  `group_split=false`), so the same mouse can appear in train and test (leakage; optimistic, like the base
+  model).
+- **Cross-validation:** 5-fold CV (`--cv-folds 5`); each fold trained on ~260 sessions, validated on 66,
+  tested on 81–82. Reported test numbers are the **out-of-fold (OOF)** pool over all 408 sessions.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311 ≈ 24% positive); sequence length median 236, P95 704, capped at 256.
+- **What was adapted vs the base model (lever H = CV of D):** balanced minibatch sampler
+  (`--sampler balanced`) with class weighting off (`--pos-weight-beta 0.0`, `loss=bce`) — the D recipe,
+  here wrapped in 5-fold CV instead of a single split. Both the model family (BiLSTM vs XGBoost) and the
+  input representation (sequence vs aggregated) change too.
+
+## Results (test set)
+Out-of-fold pool over all 408 sessions (early stopping on val AUC; folds ran 17–28 epochs).
+
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.840 | 0.321 | — |
+| Recall | 0.572 | 0.649 | — |
+| F1 | 0.681 | 0.430 | weighted **0.621** |
+| Accuracy | | | **0.591** (train n/a) |
+
+Also: test AUC 0.632, balanced accuracy 0.611, MCC 0.189, PR-AUC (avg precision) 0.327.
+Per-fold AUC ranged 0.577–0.779 (fold mean 0.673 ± 0.067) and accuracy 0.354–0.765 (mean 0.591 ± 0.144) —
+very unstable across folds.
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 178, WT→HT 133], [HT→WT 34, HT→HT 63]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.591 | 0.733 | −0.142 |
+| Weighted F1 | 0.621 | 0.749 | −0.128 |
+| WT F1 | 0.681 | 0.785 | −0.104 |
+| HT F1 | 0.430 | 0.649 | −0.219 |
+| HT recall | 0.649 | 0.940 | −0.291 |
+| HT precision | 0.321 | 0.496 | −0.175 |
+
+*Directional only: this NN is scored on ~408 session-level sequences (81–82 per fold) while the tabular
+base is scored on ~2,465 recording-level rows — not a like-for-like comparison.*
+
+## Key insights
+- **No degenerate collapse, but a weak model.** The balanced sampler keeps both classes alive (WT recall
+  0.572, HT recall 0.649 — both well off 0/1), so it avoids the all-HT or all-WT failure. The cost is a
+  mediocre operating point: overall accuracy 0.591 and AUC 0.632 are near chance for this 76/24 split.
+- **HT detection collapses on every axis vs base** — HT precision 0.321, recall 0.649, F1 0.430
+  (−0.219). About 2 of 3 HT calls are false positives (133 WT misrouted to HT), and it still misses ~35%
+  of HT pups. The base XGBoost trades far better.
+- **Folds are highly unstable** — accuracy spans 0.354 (fold 3) to 0.765 (fold 5) and AUC 0.577–0.779;
+  std 0.144 on accuracy. With only ~80 test sessions per fold, any single-split BiLSTM number is unreliable
+  — the CV exists precisely to expose this variance.
+- **Early stopping fires fast** (best val AUC at epochs ~2–13, training stops by 17–28) while train acc
+  climbs to 0.85+; the BiLSTM overfits the small session set quickly and val AUC never recovers.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — OOF confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — OOF ROC (AUC 0.632). `plots/training_curves.png` — per-fold loss/acc/AUC curves.
+- `model/bilstm_fold1.pt` … `bilstm_fold5.pt` — one fitted BiLSTM per CV fold.
+- Metrics source: `results.json` (`cv` block + OOF `classification_report`) + `logs/out.txt` (split, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/H_cv_Dsampler__bilstm__independent/README.md
+++ b/results/neural_networks/experiments/H_cv_Dsampler__bilstm__independent/README.md
@@ -1,0 +1,77 @@
+# H_cv_Dsampler__bilstm__independent — BiLSTM · subject-independent · experiment H (5-fold CV of config D)
+
+> 5-fold cross-validation of the balanced-sampler BiLSTM, evaluated **leak-free** (folds grouped by mouse).
+
+## Overview
+- **Model:** BiLSTM (2 layers, hidden 64, dropout 0.3; ~149K params). Input is a chronological
+  per-syllable sequence (order preserved, `max_seq_len=256`), scored at **session level** — not the 48
+  aggregated per-recording features the tabular base uses.
+- **Evaluation split:** subject-independent — folds split **by mouse** (`--independent` / group-split),
+  so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than
+  the dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311, ~24% positive). Sequence lengths min 1 / median 236 / P95 704.
+- **What was adapted vs the base model (lever H = CV of config D):** config D (**balanced minibatch
+  sampler**, `pos_weight_beta=0.0`, BCE loss) re-run as **5-fold CV**, so the headline metrics are
+  out-of-fold over all 408 sessions instead of a single test split. Two levers also change vs base:
+  model family (BiLSTM instead of XGBoost) **and** evaluation moves from subject-dependent to
+  subject-independent.
+
+## Results (test set)
+Out-of-fold over all 408 sessions (5 folds, ~81–83 test sessions each):
+
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.802 | 0.285 | — |
+| Recall | 0.572 | 0.546 | — |
+| F1 | 0.668 | 0.375 | weighted **0.598** |
+| Accuracy | | | **0.566** (balanced 0.559) |
+
+AUC 0.586 (OOF) · macro-F1 0.521 · MCC 0.101. Per-fold CV: AUC **0.689 ± 0.089**, balanced
+accuracy 0.563 ± 0.063, accuracy 0.566 ± **0.167** (folds range 0.284 → 0.753), MCC 0.141 ± 0.112.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.566 | 0.733 | −0.167 |
+| Weighted F1 | 0.598 | 0.749 | −0.151 |
+| WT F1 | 0.668 | 0.785 | −0.117 |
+| HT F1 | 0.375 | 0.649 | −0.274 |
+| HT recall | 0.546 | 0.940 | −0.394 |
+| HT precision | 0.285 | 0.496 | −0.211 |
+
+*Comparison is directional, not like-for-like: this BiLSTM is scored on 408 session-level sequences
+(~81–83 per fold), while the tabular base is scored on ~2,465 recording-level rows under the easier
+subject-dependent split.*
+
+## Key insights
+- **No degenerate collapse, but weak separation.** Both classes get real predictions (WT recall 0.572,
+  HT recall 0.546), so the balanced sampler avoids the all-HT / all-WT failure seen elsewhere — yet OOF
+  AUC is only 0.586 and accuracy 0.566, barely above chance for this ~24%-positive task.
+- **HT is essentially unusable at the default cut:** precision 0.285 (≈7 of 10 HT calls are false
+  positives), F1 0.375. The model trades the base's HT-heavy operating point (recall 0.940) for a
+  symmetric-but-noisy one (HT recall 0.546), losing on every HT metric.
+- **High cross-fold variance is the real story:** per-fold accuracy spans 0.284 → 0.753 and AUC 0.556 →
+  0.825 across only ~81 test sessions per fold. With 106 mice the leak-free signal is fold-dependent;
+  the fold-mean AUC 0.689 looks healthier than the OOF AUC 0.586, but the ±0.089 / ±0.167 spreads show
+  it is not reliable.
+- Early stopping fired at 16–35 epochs per fold (best val AUC 0.671–0.912); train accuracy is not
+  reported (`train_accuracy: null`) because metrics are aggregated across folds.
+
+## Recommendations
+- CV confirms config D does not generalize on this small independent split — the leak-free signal is
+  too weak and fold-variance too high for a session-level BiLSTM at ~408 sessions. Prefer the tabular
+  independent runs (e.g. `../../tabular_models/`) for any honest "new-mouse" estimate.
+- If pursuing NN further, gather more sequences or pool strains before re-tuning; the current per-fold
+  AUC range (0.556–0.825) indicates results are dominated by which mice land in each fold, not by the
+  recipe.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — aggregated confusion matrix
+  (normalized + counts). `plots/roc_curve.png` — OOF ROC. `plots/training_curves.png` — per-fold
+  loss/accuracy/AUC curves.
+- `model/bilstm_fold1.pt` … `bilstm_fold5.pt` — the five fitted fold checkpoints.
+- Metrics source: `results.json` (`cv` block + out-of-fold `classification_report`) · `logs/out.txt`
+  (flags, split info, class balance, per-epoch / per-fold history).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/experiments/README.md
+++ b/results/neural_networks/experiments/README.md
@@ -1,0 +1,41 @@
+# `experiments/` — sequence-model lever sweep (A–H)
+
+Index of the neural-network experiment matrix: each lever is tried to fix the two problems the
+[baseline NN runs](../) hit — **class imbalance** (HT ≈ 24%) and **data scarcity** (only ~19 HT test
+sessions on the independent split), which together cause the models to collapse onto a single class.
+
+Every experiment runs on the official `--baseline` sequence data across both eval splits and (most) three
+architectures (BiLSTM / 1D-CNN / Transformer). Each child folder has its own `README.md` with full
+results and Δ vs the base model (`../../tabular_models/xgboost_subject_eval_dependent_baseline`).
+
+## The levers
+| Prefix | Lever | What it changes |
+|---|---|---|
+| **A** | control | defaults (`pos_weight_beta=1.0`, no sampler, BCE) — the unmodified starting point |
+| **B** | beta0.5 | milder class weighting: `pos_weight = (n_WT/n_HT)^0.5` |
+| **C** | beta0 | no class weighting (`pos_weight=1.0`), raw BCE |
+| **D** | sampler | balanced minibatch sampler (~50/50 per batch) + `beta=0` — **most reliable fix** |
+| **E** | focal | focal loss (γ=2.0), confidence-based reweighting |
+| **F** | regsmall | weight-decay + high dropout + smaller net, to fight overfit on the tiny independent split |
+| **G** | augment | sliding-window augmentation of long train sessions |
+| **H** | cv_Dsampler | 5-fold cross-validation of the **D** config (robustness check) |
+
+## Full results
+The ranked master table and the styled report live in [`_summary/`](_summary/):
+- [`_summary/master_metrics.md`](_summary/master_metrics.md) — all runs ranked by balanced accuracy.
+- `_summary/master_metrics.csv` — same data for analysis.
+- `_summary/executive_summary.html` — narrative report.
+
+## Key takeaways
+- **D (balanced sampler) is the most reliable lever** — it rescues the BiLSTM all-HT collapse
+  (dependent balanced-acc 0.500 → 0.628; WT recall 0% → 73%) where pure loss-weighting (A/B/C) does not.
+- **The Transformer rarely collapses** — its control (A) is often already its best config.
+- **H (CV) is the honesty check:** the dependent improvement holds up (≈0.61 ± 0.06), but the strong
+  single-split *independent* numbers are a lucky-fold artifact — the 5-fold estimate (≈0.56 ± 0.06)
+  confirms independent generalization is **data-limited**, not recoverable by these levers alone.
+
+## Regenerate
+```bash
+python src/classification/neural_networks/sequence_pipeline.py --baseline --model {bilstm,cnn1d,transformer} [--independent] <lever flags>
+python scripts/generate_nn_executive_summary.py --results-root results/neural_networks/experiments
+```

--- a/results/neural_networks/transformer_subject_eval_dependent_baseline/README.md
+++ b/results/neural_networks/transformer_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,59 @@
+# transformer_subject_eval_dependent_baseline — Transformer · subject-dependent
+
+> Transformer sequence classifier on the official baseline data, evaluated subject-**dependent** (random session-level split; mice leak across train/test).
+
+## Overview
+- **Model:** Transformer (~73K params) over a chronological per-syllable sequence (syllable order
+  preserved, `MAX_SEQ_LEN=256`), unlike the tabular base model's 48 aggregated per-recording features.
+  Scored at **session level**, not recording level.
+- **Evaluation split:** subject-dependent — random **session-level** split (`--baseline`, no
+  `--independent`/`--group-split`), so the same mouse can sit in train and test (the log flags
+  `mouse overlap -- train/val: 56, train/test: 61 shared mice`). This is the optimistic, leaky setting,
+  same family as the dependent base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions from
+  106 mice (HT 97 / WT 311). Split 244 train / 82 val / 82 test sessions; test = HT 23% / WT 77%.
+- **Training:** `pos_weight=3.207` class weighting, early stopping at epoch 31/100 on best val AUC 0.688.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.872 | 0.371 | — |
+| Recall | 0.651 | 0.684 | — |
+| F1 | 0.745 | 0.481 | weighted **0.684** |
+| Accuracy | | | **0.659** (train 0.684) |
+
+Test AUC-ROC 0.655. Support: WT 63, HT 19 (82 test sessions).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.659 | 0.733 | −0.074 |
+| Weighted F1 | 0.684 | 0.749 | −0.065 |
+| WT F1 | 0.745 | 0.785 | −0.040 |
+| HT F1 | 0.481 | 0.649 | −0.168 |
+| HT recall | 0.684 | 0.940 | −0.256 |
+| HT precision | 0.371 | 0.496 | −0.125 |
+
+*Directional only, not like-for-like: this NN is scored on 82 session-level sequences, whereas the
+tabular base model is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- The Transformer is **worse than the dependent tabular base on every headline metric**, despite the
+  same leaky split that should flatter it: accuracy −0.074, weighted F1 −0.065, HT F1 −0.168. The
+  per-syllable sequence view does not beat 48 aggregated features here.
+- No degenerate collapse — both classes are predicted (HT recall 0.684, WT recall 0.651) — but the
+  minority class is the weak spot: **HT precision 0.371** means roughly 2 of every 3 HT calls are false
+  positives, and HT recall (0.684) is far below the base model's 0.940.
+- Train 0.684 vs test 0.659 shows almost no train/test gap on accuracy, yet train AUC 0.817 vs test AUC
+  0.655 reveals the model fits the train sequences better than it generalizes — even with mouse leakage.
+- The fit is shallow overall: best val AUC plateaued at 0.688 by epoch 16 and never improved through
+  early stopping at epoch 31; the tiny 244-session train set caps what a Transformer can learn.
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.655). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- `logs/out.txt` — flags, split info, class balance, per-epoch log, early stopping.
+- Metrics source: `results.json` + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/neural_networks/transformer_subject_eval_independent_baseline/README.md
+++ b/results/neural_networks/transformer_subject_eval_independent_baseline/README.md
@@ -1,0 +1,66 @@
+# transformer_subject_eval_independent_baseline — Transformer · subject-independent
+
+> Transformer on the official baseline sequences, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** Transformer encoder over per-syllable sequences (72,537 params). Input is the chronological
+  per-syllable sequence (order preserved, `MAX_SEQ_LEN=256`), not the 48 aggregated per-recording
+  features the tabular base model uses. Scored at **session level**.
+- **Evaluation split:** subject-independent — group-aware split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). 408 sessions (HT=97 / WT=311) from
+  106 mice. Test = 90 sessions from 22 held-out mice (WT 79% / HT 21%);
+  train 238 / val 80.
+- **Training:** `pos_weight=3.250` (control-style class weighting), early-stopped at epoch 29 on best
+  val AUC 0.810. Test AUC drops to 0.675 — the validation operating point did not transfer.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.895 | 0.288 | — |
+| Recall | 0.479 | 0.789 | — |
+| F1 | 0.624 | 0.423 | weighted **0.581** |
+| Accuracy | | | **0.544** (train 0.605) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 34, WT→HT 37], [HT→WT 4, HT→HT 15]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.544 | 0.733 | −0.189 |
+| Weighted F1 | 0.581 | 0.749 | −0.168 |
+| WT F1 | 0.624 | 0.785 | −0.161 |
+| HT F1 | 0.423 | 0.649 | −0.226 |
+| HT recall | 0.789 | 0.940 | −0.151 |
+| HT precision | 0.288 | 0.496 | −0.208 |
+
+*Directional only, not like-for-like: this NN is scored on 90 session-level sequences, whereas the
+tabular base model is scored on ~2,465 recording-level rows.*
+
+## Key insights
+- **Minority-leaning collapse.** The model tips toward HT: HT recall 0.789 but WT recall only 0.479, so
+  it mislabels 37 of 71 WT sessions as HT. This is the milder side of the common NN collapse — driven by
+  the `pos_weight=3.250` weighting — and it sinks overall accuracy to 0.544.
+- **The operating point did not transfer.** Best val AUC 0.810 vs test AUC 0.675, and at the
+  best-AUC checkpoint the 0.5 threshold yields val acc ~0.70 but test acc 0.544 — the tiny
+  independent split (22 test mice, 19 HT) makes the chosen cut unstable.
+- **HT precision ≈ 0.29** (−0.208 vs base): nearly 3 of every 4 HT calls are false positives, the worst
+  HT precision among the baseline runs; HT F1 0.423.
+- Train acc 0.605 is barely above test 0.544 — this is underfitting, not overfitting; the Transformer
+  never found a clean WT/HT boundary on these sequences.
+
+## Recommendations
+- Prefer the balanced-sampler config (`D` prefix) over raw `pos_weight` weighting — it is the most
+  reliable fix for this minority-leaning collapse on the independent split.
+- Do not deploy this 0.5-threshold operating point; if this architecture is pursued, retune the cut on a
+  validation set that better matches the test distribution (see `../threshold/`,
+  `../threshold_objectives/`).
+
+## Artifacts
+- `plots/confusion_matrix.png`, `plots/confusion_matrix_counts.png` — confusion matrices (normalized + counts).
+- `plots/roc_curve.png` — test ROC (AUC 0.675). `plots/training_curves.png` — loss/acc/AUC per epoch.
+- `model/transformer_best.pt` — best checkpoint. `model/scaler.pkl` — feature scaler.
+- Metrics source: `results.json` + `logs/out.txt` (flags, split info, class balance, early stopping).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `results.json` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/README.md
+++ b/results/tabular_models/strain/README.md
@@ -1,0 +1,46 @@
+# `strain/` — per-cohort tabular runs (strain1 vs strain2)
+
+Index of the 12 tabular runs trained on a **single strain cohort** instead of the pooled corpus, to
+test whether the two cohorts behave differently. Each child folder has its own `README.md` with the full
+summary, results, and Δ vs the base model (`results/tabular_models/xgboost_subject_eval_dependent_baseline`).
+
+## Cohorts
+- **strain1** — years **2022–2024**, mixed `BALB/C+C57` background (the newer litters).
+- **strain2** — years **2015/2018**, pure `BALB/c` (the classic published cohort).
+
+Matrix: 3 models (`xgboost`, `xgboost_tuned_dependent`, `tabpfn`) × 2 strains × 2 eval splits
+(dependent / independent). All on the official `--baseline` data (Issue #46 filters + April-2026 HET→WT
+correction).
+
+## Runs at a glance (test set)
+| Run | Acc | Weighted F1 | HT F1 |
+|---|---|---|---|
+| [xgboost_strain1 · dependent](xgboost_strain1_subject_eval_dependent_baseline/) | 0.774 | 0.791 | 0.657 |
+| [xgboost_strain1 · independent](xgboost_strain1_subject_eval_independent_baseline/) | 0.903 | 0.909 | 0.753 |
+| [xgboost_strain2 · dependent](xgboost_strain2_subject_eval_dependent_baseline/) | 0.748 | 0.759 | 0.642 |
+| [xgboost_strain2 · independent](xgboost_strain2_subject_eval_independent_baseline/) | 0.657 | 0.609 | 0.122 |
+| [xgboost_tuned_dependent_strain1 · dependent](xgboost_tuned_dependent_strain1_subject_eval_dependent_baseline/) | 0.789 | 0.802 | 0.649 |
+| [xgboost_tuned_dependent_strain1 · independent](xgboost_tuned_dependent_strain1_subject_eval_independent_baseline/) | 0.899 | 0.903 | 0.729 |
+| [xgboost_tuned_dependent_strain2 · dependent](xgboost_tuned_dependent_strain2_subject_eval_dependent_baseline/) | 0.783 | 0.790 | 0.657 |
+| [xgboost_tuned_dependent_strain2 · independent](xgboost_tuned_dependent_strain2_subject_eval_independent_baseline/) | 0.653 | 0.597 | 0.081 |
+| [tabpfn_strain1 · dependent](tabpfn_strain1_subject_eval_dependent_baseline/) | 0.785 | 0.801 | 0.680 |
+| [tabpfn_strain1 · independent](tabpfn_strain1_subject_eval_independent_baseline/) | 0.897 | 0.905 | 0.749 |
+| [tabpfn_strain2 · dependent](tabpfn_strain2_subject_eval_dependent_baseline/) | 0.801 | 0.809 | 0.703 |
+| [tabpfn_strain2 · independent](tabpfn_strain2_subject_eval_independent_baseline/) | 0.654 | 0.659 | 0.388 |
+
+## Key takeaways
+- **strain1 independent is the standout** (~0.90 acc / 0.73–0.75 HT F1 across all three models) — higher
+  than its own dependent split, the opposite of the usual dependent→independent drop. Read it cautiously:
+  it is a single favourable group split on the larger, more homogeneous newer cohort, not necessarily a
+  robust generalization gain.
+- **strain2 independent collapses** (acc ~0.65, HT F1 0.08–0.39): the smaller 2015/2018 cohort has too
+  few held-out HT mice for a leak-free split — TabPFN (HT F1 0.388) degrades least, the tuned XGBoost
+  (0.081) most.
+- **Dependent splits are consistent across strains** (~0.75–0.80 acc), in line with the pooled base model.
+- Model choice matters little within a cohort/split; the **cohort × split interaction** dominates —
+  evidence the two strains are not interchangeable and should not be pooled blindly.
+
+## Regenerate
+```bash
+python src/classification/tabular/train_classifier.py --baseline --strain {1,2} [--independent] --model {xgboost,xgboost_tuned_dependent,tabpfn}
+```

--- a/results/tabular_models/strain/tabpfn_strain1_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/strain/tabpfn_strain1_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,66 @@
+# tabpfn_strain1_subject_eval_dependent_baseline — TabPFN · subject-dependent · strain1
+
+> TabPFN on the strain1 cohort (2022–2024, mixed BALB/c+C57), evaluated **subject-dependent** (rows split randomly, mice leak across train/test).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve and no feature importance).
+- **Evaluation split:** subject-dependent — train/val/test split at the **row level** (random), so the
+  same mouse appears in train, val and test (the run logs a 59-mouse overlap across all three). This is
+  the optimistic/leaky setting, matching the dependent base model.
+- **Cohort:** strain1 only — years 2022–2024, mixed BALB/c+C57 background. The strain filter keeps
+  7,572/12,323 baseline recordings (`pup_strain == 1`) from 59 mice.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 1,515 recordings (WT 76.4% / HT 23.6%); train 4,542 + val 1,515 rows, with val merged into the
+  6,057 fitting rows.
+- **What was adapted vs the base model:** model family (TabPFN instead of XGBoost) **and** the data is
+  restricted to the strain1 sub-cohort; the dependent split itself is unchanged.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.987 | 0.523 | — |
+| Recall | 0.728 | 0.969 | — |
+| F1 | 0.838 | 0.680 | weighted **0.801** |
+| Accuracy | | | **0.785** (train 0.847) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 843, WT→HT 315], [HT→WT 11, HT→HT 346]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.785 | 0.733 | +0.052 |
+| Weighted F1 | 0.801 | 0.749 | +0.052 |
+| WT F1 | 0.838 | 0.785 | +0.053 |
+| HT F1 | 0.680 | 0.649 | +0.031 |
+| HT recall | 0.969 | 0.940 | +0.029 |
+| HT precision | 0.523 | 0.496 | +0.027 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the cleaner strain1 cohort TabPFN beats the full-data XGBoost base on **every** headline metric —
+  accuracy 0.785 (+0.052), weighted F1 0.801 (+0.052) — but the comparison is partly apples-to-oranges
+  (a single, more homogeneous strain vs the all-strains base).
+- The operating point is aggressive on the minority class: **HT recall 0.969** (catches all but 11 of
+  357 ASD-model pups) at the cost of **HT precision 0.523** — roughly half of HT calls are false
+  positives (315 WT→HT). HT F1 0.680.
+- WT recall is the weak side (0.728): 315 of 1,158 controls are mislabelled HT, mirroring the high WT
+  precision / low HT precision asymmetry seen across these tabular runs.
+- Train 0.847 vs test 0.785 (≈0.06 gap) is small — but this is the leaky dependent split, so it
+  flatters generalization; treat it as an upper bound, not a new-mouse estimate.
+
+## Recommendations
+- Read alongside an independent (by-mouse) strain1 run before trusting these numbers — dependent splits
+  on a single cohort are especially optimistic given the 59-mouse train/test overlap.
+- HT precision ≈ 0.52 at the default 0.5 cut means positive calls need confirmation; a threshold sweep
+  would let you trade some of the near-perfect HT recall for fewer false positives.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices (single-strain run; no
+  per-strain split).
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, strain filter, split info, class
+  balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/tabpfn_strain1_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/strain/tabpfn_strain1_subject_eval_independent_baseline/README.md
@@ -1,0 +1,67 @@
+# tabpfn_strain1_subject_eval_independent_baseline — TabPFN · subject-independent · strain1
+
+> TabPFN on the strain1 cohort (2022–2024, mixed BALB/C+C57), evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware by `mouse_idx`), so no mouse appears in two sets. This is the honest "generalize to unseen
+  mice" setting (harder than the dependent base model, which splits rows randomly and lets mice leak
+  across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), restricted to
+  **strain1** (2022–2024, mixed BALB/C+C57): kept 7,572/12,323 rows (`pup_strain == 1`) from 59 mice.
+  Test = 1,693 recordings from 12 held-out mice (WT 83.5% / HT 16.5%).
+- **What was adapted vs the base model:** three levers change together — model family (TabPFN instead of
+  XGBoost), evaluation moves from subject-dependent to subject-independent, **and** the data is narrowed
+  to the strain1 cohort.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.984 | 0.629 | — |
+| Recall | 0.892 | 0.925 | — |
+| F1 | 0.935 | 0.749 | weighted **0.905** |
+| Accuracy | | | **0.897** (train 0.859) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1260, WT→HT 153], [HT→WT 21, HT→HT 259]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.897 | 0.733 | +0.164 |
+| Weighted F1 | 0.905 | 0.749 | +0.156 |
+| WT F1 | 0.935 | 0.785 | +0.150 |
+| HT F1 | 0.749 | 0.649 | +0.100 |
+| HT recall | 0.925 | 0.940 | −0.015 |
+| HT precision | 0.629 | 0.496 | +0.133 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The strain1 cohort is the strongest TabPFN result yet: **accuracy 0.897 and weighted F1 0.905**, both
+  ~0.16 above the dependent base model — and this is the *honest* leak-free split, which usually costs
+  10–15 pts rather than gaining them. The narrower, more recent cohort is clearly easier to separate.
+- Minority-class quality jumps: **HT precision 0.629 (+0.133)** with HT recall held at 0.925 (−0.015),
+  lifting HT F1 to 0.749 (+0.100). Far fewer false positives than the full-data TabPFN (where HT
+  precision sat at ~0.50) while still catching ~93% of ASD-model pups.
+- WT is almost airtight — precision 0.984, recall 0.892 — so the 153 WT→HT misses dominate the error
+  budget; only 21 HT pups are missed.
+- Train 0.859 sits **below** test 0.897, an unusual inverted gap: the test cohort (16.5% HT) is more
+  WT-skewed than train (22.2% HT), and TabPFN merges val into train, so the train figure is not a clean
+  fit estimate.
+
+## Recommendations
+- Treat this strain1 score as cohort-specific, not a general headline: the gain partly reflects an
+  easier, more recent, lower-HT-prevalence cohort (16.5% vs ~24% overall). Cross-check against
+  strain2 before claiming broad generalization.
+- HT precision (0.63) still leaves ~1 in 3 positive calls as false alarms; if a higher-purity operating
+  point is needed, see the threshold runs (`../../threshold/`, `../../threshold_objectives/`).
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices (single-strain run, no
+  per-strain split).
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/tabpfn_strain2_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/strain/tabpfn_strain2_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,61 @@
+# tabpfn_strain2_subject_eval_dependent_baseline — TabPFN · subject-dependent · strain2
+
+> TabPFN on the strain2 (pure BALB/c, 2015/2018) baseline cohort, evaluated subject-**dependent** (random row split — mice leak across train/test).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve or feature importance).
+- **Evaluation split:** subject-dependent — random **row-level** split, so the same mouse appears in
+  train, val and test (`mouse overlap -- train/test: 47 shared mice`). This is the optimistic,
+  leak-prone setting (matches the base model's split type).
+- **Cohort:** strain2 — the pure BALB/c classic published cohort (years 2015/2018). The strain filter
+  kept 4,751 / 12,323 rows (`pup_strain == 2`), 47 mice.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 951 recordings (WT 72.0% / HT 28.0%); train+val 3,800 rows after the val→train merge.
+- **What was adapted vs the base model:** two levers change together — model family (TabPFN instead of
+  XGBoost) **and** the data is restricted to the single strain2 cohort (same dependent split type).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.928 | 0.604 | — |
+| Recall | 0.785 | 0.842 | — |
+| F1 | 0.851 | 0.703 | weighted **0.809** |
+| Accuracy | | | **0.801** (train 0.926) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 538, WT→HT 147], [HT→WT 42, HT→HT 224]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.801 | 0.733 | +0.068 |
+| Weighted F1 | 0.809 | 0.749 | +0.060 |
+| WT F1 | 0.851 | 0.785 | +0.066 |
+| HT F1 | 0.703 | 0.649 | +0.054 |
+| HT recall | 0.842 | 0.940 | −0.098 |
+| HT precision | 0.604 | 0.496 | +0.108 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the clean single-strain BALB/c cohort TabPFN beats the base model on the aggregate metrics:
+  accuracy 0.801 (+0.068) and weighted F1 0.809 (+0.060) — the homogeneous 2015/2018 data is
+  easier to separate than the mixed-background full set.
+- The operating point is far better balanced than the base model: **HT precision jumps to 0.604**
+  (+0.108) while HT recall eases to 0.842 (−0.098), lifting HT F1 to 0.703 (+0.054). Fewer false
+  positives at a modest cost in catching ASD-model pups.
+- This is still the **optimistic dependent split** — all 47 mice leak across train/test, so these
+  numbers overstate generalization to unseen mice (expect ~10–15 pts lower under an independent split).
+- Train 0.926 vs test 0.801 (0.13 gap); TabPFN merges val into train, which inflates the train figure.
+
+## Recommendations
+- Treat these as an in-distribution ceiling for the strain2 cohort, not a new-mouse estimate; pair with
+  a subject-independent strain2 run before claiming generalization.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices (single-strain run, no
+  per-strain split).
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/tabpfn_strain2_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/strain/tabpfn_strain2_subject_eval_independent_baseline/README.md
@@ -1,0 +1,66 @@
+# tabpfn_strain2_subject_eval_independent_baseline — TabPFN · subject-independent · strain2
+
+> TabPFN on the **strain2** (2015/2018 pure BALB/c) cohort, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Cohort:** strain2 — the 2015/2018 pure BALB/c classic published cohort (`--strain 2`).
+  Filter kept 4,751 / 12,323 recordings (47 mice).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 1,176 recordings from 10 held-out mice (WT 73.2% / HT 26.8%); train 2,844 / val 731 rows.
+- **What was adapted vs the base model:** three levers change together — model family (TabPFN instead of
+  XGBoost), evaluation moves subject-dependent → subject-independent, **and** the data is narrowed to the
+  strain2 sub-cohort rather than the full baseline.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.775 | 0.369 | — |
+| Recall | 0.743 | 0.410 | — |
+| F1 | 0.759 | 0.388 | weighted **0.659** |
+| Accuracy | | | **0.654** (train 0.941) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 640, WT→HT 221], [HT→WT 186, HT→HT 129]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.654 | 0.733 | −0.079 |
+| Weighted F1 | 0.659 | 0.749 | −0.090 |
+| WT F1 | 0.759 | 0.785 | −0.026 |
+| HT F1 | 0.388 | 0.649 | −0.261 |
+| HT recall | 0.410 | 0.940 | −0.530 |
+| HT precision | 0.369 | 0.496 | −0.127 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The minority class collapses: **HT recall drops to 0.410** (−0.530 vs base) — the model now misses
+  nearly 6 in 10 ASD-model pups (186 of 315 HT cases predicted WT). HT F1 falls to 0.388 (−0.261).
+- HT precision is also weak at **0.369** (−0.127): under half the strain2 test mice are HT, and the
+  model is wrong on most of its positive calls (221 false positives vs 129 true positives).
+- Overall accuracy (0.654) and weighted F1 (0.659) sit ~0.08–0.09 below the dependent base model — the
+  combined cost of the leak-free split plus the much smaller, single-cohort strain2 training pool (only
+  27 train mice, ~2.8k rows after merging val).
+- Train 0.941 vs test 0.654 (0.29 gap) is the widest of the TabPFN runs and reflects the difficulty of
+  generalizing across unseen mice within the small strain2 cohort; TabPFN merges val into train, which
+  inflates the train figure.
+
+## Recommendations
+- HT performance is poor on both axes at the default 0.5 cut; this strain2-only independent run is not a
+  usable operating point — prefer the full-baseline TabPFN independent run, and see the threshold runs
+  for recall-controlled cuts.
+- If a strain2-specific model is needed, the 47-mouse cohort is likely too small for leak-free TabPFN;
+  consider pooling strains or treating strain as a feature rather than a hard filter.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices (single-strain run, no
+  per-strain split).
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_strain1_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_strain1_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,59 @@
+# xgboost_strain1_subject_eval_dependent_baseline — XGBoost · subject-dependent · strain1
+
+> Untuned XGBoost on the strain1 cohort (2022–2024, mixed BALB/C+C57), evaluated on the leaky dependent split.
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe; `scale_pos_weight=3.53` to up-weight the HT minority).
+- **Evaluation split:** subject-dependent — random row-level split, so the same mouse appears in train,
+  val and test (the log warns: 59/59/59 shared mice). This leaks and reads optimistically vs an
+  independent split.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), restricted to
+  **strain1** (`--strain 1`, 2022–2024, mixed BALB/C+C57): kept 7,572/12,323 rows over 59 mice
+  (WT 5,891 / HT 1,681). Train 4,542 / Val 1,515 / Test 1,515 rows; test is WT 76.4% / HT 23.6%.
+- **What was adapted vs the base model:** one lever — the data is restricted to the strain1 cohort;
+  model family and dependent split match the base.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.967 | 0.512 | — |
+| Recall | 0.730 | 0.919 | — |
+| F1 | 0.832 | 0.657 | weighted **0.791** |
+| Accuracy | | | **0.774** (train 0.811) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 845, WT→HT 313], [HT→WT 29, HT→HT 328]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.774 | 0.733 | +0.041 |
+| Weighted F1 | 0.791 | 0.749 | +0.042 |
+| WT F1 | 0.832 | 0.785 | +0.047 |
+| HT F1 | 0.657 | 0.649 | +0.008 |
+| HT recall | 0.919 | 0.940 | −0.021 |
+| HT precision | 0.512 | 0.496 | +0.016 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Restricting to the **strain1 cohort lifts every headline metric** vs the full-data base: accuracy
+  +0.041 (0.774), weighted F1 +0.042 (0.791), WT F1 +0.047. A single more-homogeneous cohort is easier
+  to separate than the pooled dataset.
+- The minority class barely moves: **HT F1 0.657 (+0.008)** — HT precision nudges up to 0.512 (+0.016)
+  while HT recall dips to 0.919 (−0.021). Both gains land entirely on the WT side.
+- Class separation is still weak — **HT precision ≈ 0.51**, so about half of HT predictions are false
+  positives (313 WT mislabeled HT vs 328 true HT). The model keeps the base's aggressive high-recall
+  operating point on the minority.
+- Train 0.811 vs test 0.774 (0.04 gap) is modest, but the dependent split leaks (mice shared across all
+  three sets), so this is an optimistic read — expect ~10–15 pts lower on a leak-free strain1 split.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices (single-strain run, no
+  per-strain CM split).
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importances.
+  `plots/AUC_error.png` — training/eval curve.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, strain filter, split info, class
+  balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_strain1_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_strain1_subject_eval_independent_baseline/README.md
@@ -1,0 +1,66 @@
+# xgboost_strain1_subject_eval_independent_baseline — XGBoost · subject-independent · strain1
+
+> Untuned legacy XGBoost on the strain1 cohort (2022–2024 mixed BALB/C+C57), evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe; class imbalance handled via `scale_pos_weight=3.5104`,
+  HT = positive). 48 aggregated per-recording acoustic features.
+- **Evaluation split:** subject-independent — group-aware train/val/test split **by mouse**
+  (`--independent`), so no mouse appears in two sets. This is the honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak across
+  train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), restricted to
+  **strain1** (years 2022–2024, mixed BALB/C+C57 background): 7,572/12,323 rows, 59 mice.
+- **Split sizes:** Train 4,569 (WT 77.8% / HT 22.2%, 35 mice) · Val 1,310 (29.6% HT, 12 mice) ·
+  Test 1,693 (WT 83.5% / HT 16.5%, 12 held-out mice).
+- **What was adapted vs the base model:** two levers change together — cohort narrows to strain1 **and**
+  evaluation moves from subject-dependent to subject-independent (same XGBoost family).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.979 | 0.648 | — |
+| Recall | 0.903 | 0.900 | — |
+| F1 | 0.939 | 0.753 | weighted **0.909** |
+| Accuracy | | | **0.903** (train 0.793) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1276, WT→HT 137], [HT→WT 28, HT→HT 252]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.903 | 0.733 | +0.170 |
+| Weighted F1 | 0.909 | 0.749 | +0.160 |
+| WT F1 | 0.939 | 0.785 | +0.154 |
+| HT F1 | 0.753 | 0.649 | +0.104 |
+| HT recall | 0.900 | 0.940 | −0.040 |
+| HT precision | 0.648 | 0.496 | +0.152 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Restricting to the strain1 cohort flips the usual dependent→independent penalty: this leak-free run
+  **beats the dependent base model by +0.170 accuracy and +0.160 weighted F1**, the cleaner single-cohort
+  signal more than offsetting the harder by-mouse split.
+- The minority class improves on both sides of the trade-off versus base — **HT precision +0.152 (0.648)**
+  and HT F1 +0.104 (0.753) — while HT recall stays high at 0.900 (only −0.040). Fewer false ASD-model
+  calls (28 WT→HT here translates to WT precision 0.979) without sacrificing recall.
+- Train 0.793 sits **below** test 0.903 — no overfitting; the untuned model is, if anything,
+  underfitting the train fold, yet generalizes cleanly to the 12 held-out mice.
+- Class separation is genuinely strong here: HT recall 0.900 with precision 0.648 means most ASD-model
+  pups are caught and ~2 in 3 positive calls are correct — a far healthier operating point than the
+  base model's 0.496 HT precision.
+
+## Recommendations
+- Use this strain1 independent run, not the dependent base, for any "new-mouse" estimate on the
+  2022–2024 cohort; results are leak-free and well-calibrated, but remain cohort-specific (do not read
+  across to strain2).
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — train/val AUC learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance rankings.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, strain filter, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_strain2_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_strain2_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,59 @@
+# xgboost_strain2_subject_eval_dependent_baseline — XGBoost · subject-dependent · strain2
+
+> Untuned XGBoost on the strain2 (pure BALB/c, 2015/2018) baseline cohort, evaluated row-level (leaky/optimistic).
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe; `scale_pos_weight=2.4462` for the HT minority).
+- **Evaluation split:** subject-dependent — random row-level split (the log warns `mouse overlap`: all
+  47 mice appear in train, val **and** test). Same mouse leaks across sets, so figures are optimistic
+  and match the base model's evaluation regime.
+- **Cohort:** strain2 only — the pure BALB/c classic published cohort (years 2015/2018). The strain
+  filter keeps 4,751/12,323 baseline rows (`pup_strain == 2`), 47 mice.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 951 recordings (WT 72.0% / HT 28.0%); train 2,850 / val 950.
+- **What was adapted vs the base model:** one lever — the data is restricted to the strain2 cohort.
+  Same model family and same subject-dependent split as the base.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.907 | 0.532 | — |
+| Recall | 0.724 | 0.808 | — |
+| F1 | 0.805 | 0.642 | weighted **0.759** |
+| Accuracy | | | **0.748** (train 0.845) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 496, WT→HT 189], [HT→WT 51, HT→HT 215]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.748 | 0.733 | +0.015 |
+| Weighted F1 | 0.759 | 0.749 | +0.010 |
+| WT F1 | 0.805 | 0.785 | +0.020 |
+| HT F1 | 0.642 | 0.649 | −0.007 |
+| HT recall | 0.808 | 0.940 | −0.132 |
+| HT precision | 0.532 | 0.496 | +0.036 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Restricting to the cleaner pure-BALB/c strain2 cohort nudges overall accuracy (0.748, +0.015) and
+  weighted F1 (0.759, +0.010) slightly above the full-data base, with the train→test gap tightening to
+  ~0.10 (0.845 vs 0.748).
+- The operating point shifts off the base's extreme HT-leaning call: **HT recall drops to 0.808**
+  (−0.132 vs base) but **HT precision climbs to 0.532** (+0.036) — fewer WT pups misfired as HT (189
+  false positives), at the cost of missing ~1 in 5 ASD-model pups.
+- Net HT F1 is essentially flat (0.642, −0.007): the recall lost and precision gained roughly cancel,
+  so strain2's gains are concentrated on the WT class (WT F1 +0.020).
+- Class separation remains weak — **HT precision ≈ 0.53**, so nearly half of HT predictions are still
+  false positives even on the homogeneous cohort, and the dependent split keeps these numbers optimistic.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC/error learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, strain filter, split info,
+  class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_strain2_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_strain2_subject_eval_independent_baseline/README.md
@@ -1,0 +1,68 @@
+# xgboost_strain2_subject_eval_independent_baseline — XGBoost · subject-independent · strain2
+
+> Untuned XGBoost on the strain2 (pure BALB/c, 2015/2018) cohort, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** XGBoost — untuned legacy recipe (no hyperparameter search), `scale_pos_weight=2.47` for the
+  minority HT class.
+- **Cohort:** strain2 — pure BALB/c classic published cohort (years 2015/2018). Strain filter keeps
+  4,751/12,323 baseline recordings (`pup_strain == 2`), 47 mice.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Train 2,844 rows / 27 mice, Val 731 / 10 mice, Test 1,176 recordings from 10 held-out mice
+  (WT 73.2% / HT 26.8%).
+- **What was adapted vs the base model:** three levers change together — cohort narrows to strain2 only,
+  evaluation moves from subject-dependent to subject-independent, and the same untuned recipe is applied
+  to a much smaller pool of mice.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.722 | 0.194 | — |
+| Recall | 0.865 | 0.089 | — |
+| F1 | 0.787 | 0.122 | weighted **0.609** |
+| Accuracy | | | **0.657** (train 0.916) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 745, WT→HT 116], [HT→WT 287, HT→HT 28]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.657 | 0.733 | −0.076 |
+| Weighted F1 | 0.609 | 0.749 | −0.140 |
+| WT F1 | 0.787 | 0.785 | +0.002 |
+| HT F1 | 0.122 | 0.649 | −0.527 |
+| HT recall | 0.089 | 0.940 | −0.851 |
+| HT precision | 0.194 | 0.496 | −0.302 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The minority class **collapses**: HT recall crashes to 0.089 (−0.851 vs base) — only 28 of 315 true HT
+  recordings are caught, while 287 are called WT. The classifier defaults to WT for almost everyone on the
+  strain2 independent split.
+- HT precision is also poor at 0.194 (−0.302), so even the few positive calls are mostly wrong; HT F1 of
+  0.122 is effectively a non-working detector for ASD-model pups.
+- Train 0.916 vs test 0.657 (0.26 gap) signals heavy overfitting: the untuned recipe memorizes the 27
+  train mice but does not generalize to the 10 unseen mice in the small pure-BALB/c cohort.
+- Headline accuracy (0.657) is misleading — it rides almost entirely on WT recall (0.865) and the 73%
+  WT base rate; weighted F1 (0.609) exposes the real weakness once the minority class is counted.
+
+## Recommendations
+- This untuned recipe does not transfer to unseen strain2 mice — use a tuned-independent recipe (heavily
+  regularized/shallow) and/or compare against the full-cohort independent runs before trusting any
+  new-mouse estimate on strain2.
+- At the default 0.5 cut HT is near-undetected; tuning the decision threshold (see `../../threshold/`,
+  `../../threshold_objectives/`) cannot rescue this without first fixing the collapse, given HT precision
+  ≈ 0.19.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC/error training curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_tuned_dependent_strain1_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_tuned_dependent_strain1_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,63 @@
+# xgboost_tuned_dependent_strain1_subject_eval_dependent_baseline — XGBoost (tuned-dependent) · subject-dependent · strain1
+
+> Tuned XGBoost on the strain1 cohort, evaluated **subject-dependent** (rows split randomly, mice leak across train/test — optimistic).
+
+## Overview
+- **Model:** XGBoost with the `tuned_dependent` recipe (hyperparameters from a 200-trial random search
+  tuned for the dependent split). `scale_pos_weight=3.5284` applied for the HT minority.
+- **Evaluation split:** subject-dependent — random row-level split. The log flags **mouse overlap**
+  (59 mice shared across train/val/test), so the same mouse appears in train and test. This is the
+  leaky, optimistic setting that matches the base model's split type.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), restricted to
+  **strain1** (2022–2024, mixed BALB/C+C57). Strain filter kept 7,572/12,323 rows over 59 mice.
+  Test = 1,515 recordings (WT 76.4% / HT 23.6%).
+- **What was adapted vs the base model:** two levers change together — the tuned-dependent recipe
+  (vs the untuned legacy XGBoost) **and** the cohort narrows to strain1 only.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.936 | 0.533 | — |
+| Recall | 0.776 | 0.829 | — |
+| F1 | 0.849 | 0.649 | weighted **0.802** |
+| Accuracy | | | **0.789** (train 0.903) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 899, WT→HT 259], [HT→WT 61, HT→HT 296]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.789 | 0.733 | +0.056 |
+| Weighted F1 | 0.802 | 0.749 | +0.053 |
+| WT F1 | 0.849 | 0.785 | +0.064 |
+| HT F1 | 0.649 | 0.649 | +0.000 |
+| HT recall | 0.829 | 0.940 | −0.111 |
+| HT precision | 0.533 | 0.496 | +0.037 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the same leaky dependent split, tuning + the cleaner strain1 cohort lifts headline numbers:
+  **accuracy 0.789 (+0.056)** and **weighted F1 0.802 (+0.053)** over the base model, driven mostly by
+  WT (F1 0.849, +0.064).
+- The operating point trades minority recall for precision: **HT recall drops to 0.829 (−0.111)** while
+  **HT precision rises to 0.533 (+0.037)**. The two cancel out — **HT F1 is unchanged at 0.649**.
+- Class separation on HT is still weak — about half of HT predictions are false positives (precision
+  0.533); the model misses ~1 in 6 ASD-model pups (61 of 357).
+- Train 0.903 vs test 0.789 (0.11 gap) plus the explicit mouse-overlap warning mean these numbers are
+  optimistic; treat them as an upper bound, not a generalization estimate.
+
+## Recommendations
+- For an honest "new-mouse" estimate, use the subject-independent strain1 run rather than this
+  dependent one — this split lets mice leak across train/test.
+- HT recall sits below the base model at the default 0.5 cut; if minority recall matters, see the
+  threshold runs (`../../threshold/`, `../../threshold_objectives/`).
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — training/validation AUC + error curves.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_tuned_dependent_model.pkl` — fitted model. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_tuned_dependent_strain1_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_tuned_dependent_strain1_subject_eval_independent_baseline/README.md
@@ -1,0 +1,68 @@
+# xgboost_tuned_dependent_strain1_subject_eval_independent_baseline — XGBoost (tuned-dependent recipe) · subject-independent · strain1
+
+> Dependent-tuned XGBoost on the strain1 cohort, evaluated **leak-free** (split grouped by mouse) — a cross-split check.
+
+## Overview
+- **Model:** XGBoost with `xgboost_tuned_dependent` hyperparameters (200-trial random search tuned for the
+  subject-*dependent* split). Here they run on the *independent* split, so the tuning was optimized for a
+  different, easier setting — treat this as a cross-check, not a matched configuration.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`, group-aware
+  by `mouse_idx`), so no mouse appears in two sets. This is the honest "generalize to unseen mice" setting
+  (the dependent base model splits rows randomly and lets mice leak across train/test).
+- **Cohort:** strain1 (years 2022–2024, mixed BALB/C + C57 background). Strain filter kept 7,572/12,323
+  baseline rows (`pup_strain == 1`), 59 mice.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 1,693 recordings from 12 held-out mice (WT 83.5% / HT 16.5%); class weighting via
+  `scale_pos_weight = 3.51`.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.963 | 0.655 | — |
+| Recall | 0.914 | 0.821 | — |
+| F1 | 0.938 | 0.729 | weighted **0.903** |
+| Accuracy | | | **0.899** (train 0.903) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1292, WT→HT 121], [HT→WT 50, HT→HT 230]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.899 | 0.733 | +0.166 |
+| Weighted F1 | 0.903 | 0.749 | +0.154 |
+| WT F1 | 0.938 | 0.785 | +0.153 |
+| HT F1 | 0.729 | 0.649 | +0.080 |
+| HT recall | 0.821 | 0.940 | −0.119 |
+| HT precision | 0.655 | 0.496 | +0.159 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Despite the **harder leak-free split**, this run beats the dependent base model across the board on
+  aggregate metrics — accuracy 0.899 (+0.166) and weighted F1 0.903 (+0.154). That gain is largely the
+  strain1 restriction (a cleaner, easier 12-mouse test cohort, 83.5% WT) rather than the split being
+  forgiving; the leak-free score is high because the cohort is narrow, not because generalization is solved.
+- The operating point is far more balanced than the base model: **HT precision jumps to 0.655** (+0.159)
+  while **HT recall drops to 0.821** (−0.119). The base model caught nearly every HT (recall 0.940) but at
+  ~0.50 precision; this run trades ~12 pts of HT recall for ~16 pts of precision, halving false-positive HT
+  calls. It still misses ~1 in 5 ASD-model pups (50 of 280 HT → WT).
+- Train 0.903 vs test 0.899 shows almost no train–test gap — unusual for an independent split, and a sign
+  the strain1 test mice happen to be well-separated, not that the dependent-tuned recipe transfers cleanly.
+- Hyperparameters were tuned for the **dependent** split; the matched `xgboost_tuned_independent` recipe
+  (heavily regularized/shallow) is the right comparison for honest independent-split performance.
+
+## Recommendations
+- Treat these numbers as cohort-specific (strain1 only) and tuning-mismatched; do not read them as
+  general independent-split performance. Compare against the strain1 `xgboost_tuned_independent` run before
+  drawing conclusions.
+- If higher HT recall is needed, tune the decision threshold — see the threshold runs (`../../threshold/`,
+  `../../threshold_objectives/`); `target_recall` keeps a controlled operating point on independent splits.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC / error learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_tuned_dependent_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_tuned_dependent_strain2_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_tuned_dependent_strain2_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,66 @@
+# xgboost_tuned_dependent_strain2_subject_eval_dependent_baseline — XGBoost (tuned-dependent) · subject-dependent · strain2
+
+> Tuned XGBoost on the pure-BALB/c strain2 cohort, evaluated subject-**dependent** (optimistic row-level split).
+
+## Overview
+- **Model:** XGBoost with the `xgboost_tuned_dependent` recipe — hyperparameters from the 200-trial
+  random search tuned for the dependent split (matches this run's split, so no cross-check caveat).
+  `scale_pos_weight=2.446` weights the HT minority.
+- **Evaluation split:** subject-dependent — random row-level split (47 mice shared across
+  train/val/test, logged as a mouse-overlap warning). This is the leaky, optimistic setting; expect
+  10–15 pts above an honest by-mouse split.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction), restricted to
+  **strain2** (2015/2018 pure-BALB/c classic published cohort) — kept 4,751/12,323 rows, 47 mice
+  (WT 71.4% / HT 28.6%). Test = 951 recordings (WT 72.0% / HT 28.0%).
+- **What was adapted vs the base model:** two levers change together — the tuned-dependent recipe
+  (vs the untuned legacy base) **and** the cohort narrows to strain2 only.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.888 | 0.590 | — |
+| Recall | 0.800 | 0.741 | — |
+| F1 | 0.842 | 0.657 | weighted **0.790** |
+| Accuracy | | | **0.783** (train 0.924) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 548, WT→HT 137], [HT→WT 69, HT→HT 197]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.783 | 0.733 | +0.050 |
+| Weighted F1 | 0.790 | 0.749 | +0.041 |
+| WT F1 | 0.842 | 0.785 | +0.057 |
+| HT F1 | 0.657 | 0.649 | +0.008 |
+| HT recall | 0.741 | 0.940 | −0.199 |
+| HT precision | 0.590 | 0.496 | +0.094 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the clean strain2 cohort the tuned recipe **beats the base across headline metrics** — accuracy
+  0.783 (+0.050), weighted F1 0.790 (+0.041), WT F1 0.842 (+0.057) — consistent with the
+  homogeneous pure-BALB/c data being easier than the full mixed-background base.
+- The operating point rebalances: **HT precision climbs to 0.590** (+0.094) while **HT recall drops to
+  0.741** (−0.199). The base caught ~94% of ASD-model pups; this run misses ~1 in 4 (69 of 266 HT
+  fall through to WT), trading sensitivity for fewer false positives.
+- Net HT F1 barely moves (0.657, +0.008) — the precision gain and recall loss roughly cancel, so
+  minority-class separation is about the same despite the friendlier cohort and tuning.
+- Train 0.924 vs test 0.783 (0.14 gap) on a leaky dependent split: this is an optimistic number, not a
+  generalization estimate. Use the independent strain2 / independent runs for honest "new-mouse" claims.
+
+## Recommendations
+- HT recall fell well below the base at the default 0.5 cut — if catching ASD-model pups is the
+  priority, lower the threshold (see `../threshold/`, `../threshold_objectives/`) toward a
+  `target_recall` operating point.
+- Keep this run as a strain2-specific dependent reference only; do not compare it head-to-head with the
+  mixed-cohort base as a generalization result.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — training/validation AUC + error learning curves.
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — XGBoost feature importance.
+- `model/xgboost_tuned_dependent_model.pkl` — fitted model. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/strain/xgboost_tuned_dependent_strain2_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/strain/xgboost_tuned_dependent_strain2_subject_eval_independent_baseline/README.md
@@ -1,0 +1,67 @@
+# xgboost_tuned_dependent_strain2_subject_eval_independent_baseline — XGBoost (tuned-dependent) · subject-independent · strain2
+
+> Dependent-tuned XGBoost run **leak-free** on the pure BALB/c strain2 cohort — collapses on the minority class.
+
+## Overview
+- **Model:** XGBoost with hyperparameters from the 200-trial search tuned for the **subject-dependent**
+  split, but here applied to the **independent** split — a deliberate cross-check (the dependent recipe
+  is less regularized than the independent one and is not matched to this harder setting).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware by `mouse_idx`), so no mouse appears in two sets. Honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak).
+- **Cohort:** strain2 = 2015/2018 pure BALB/c classic published cohort (`--strain 2`); strain filter
+  kept 4,751/12,323 baseline rows, 47 mice.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 1,176 recordings from 10 held-out mice (WT 73.2% / HT 26.8%).
+- **What was adapted vs the base model:** three levers move together — split (dependent → independent),
+  cohort (all-data → strain2 only), and a tuned-dependent hyperparameter set on the wrong split.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.716 | 0.140 | — |
+| Recall | 0.871 | 0.057 | — |
+| F1 | 0.786 | 0.081 | weighted **0.597** |
+| Accuracy | | | **0.653** (train 0.950) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 750, WT→HT 111], [HT→WT 297, HT→HT 18]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.653 | 0.733 | −0.080 |
+| Weighted F1 | 0.597 | 0.749 | −0.152 |
+| WT F1 | 0.786 | 0.785 | +0.001 |
+| HT F1 | 0.081 | 0.649 | −0.568 |
+| HT recall | 0.057 | 0.940 | −0.883 |
+| HT precision | 0.140 | 0.496 | −0.356 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- **Minority-class collapse toward WT:** HT recall is 0.057 and HT F1 0.081 — the model finds only
+  18 of 315 ASD-model pups and misses the rest. Accuracy (0.653) is propped up almost entirely by the
+  WT majority; this run is not usable for ASD detection.
+- **Severe overfit:** train 0.950 vs test 0.653 (0.30 gap). The dependent-tuned recipe is too
+  unregularized for the leak-free split — it memorizes train mice and fails to generalize to the 10
+  unseen test mice, the opposite of what the independent-tuned recipe is built to avoid.
+- **HT precision also poor:** 0.140 (−0.356 vs base) — of the few HT calls it does make, most are
+  wrong, so the collapse is not even a useful "play-it-safe" tradeoff.
+- **Combined headwinds:** the small pure-BALB/c strain2 cohort (only 27 train mice) plus a leak-free
+  split plus a mismatched hyperparameter set together drive a −0.152 weighted-F1 drop versus base.
+
+## Recommendations
+- For the independent split, use the **independent-tuned** recipe (heavily regularized/shallow), not
+  this dependent-tuned one; the train/test gap here is the symptom of the mismatch.
+- Given the near-zero HT recall at the default 0.5 cut, threshold tuning alone will not recover this
+  run — the score separation is too weak. Prefer the independent-tuned strain2 run for any
+  new-mouse estimate on this cohort.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png` — confusion matrices.
+- `plots/AUC_error.png` — AUC/error learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_tuned_dependent_model.pkl` — fitted model. `logs/out.txt` — flags, split info, class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/tabpfn_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/tabpfn_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,60 @@
+# tabpfn_subject_eval_dependent_baseline — TabPFN · subject-dependent
+
+> TabPFN on the official baseline data, evaluated with a **row-level random split** (mice leak across train/test — optimistic).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve).
+- **Evaluation split:** subject-dependent — train/val/test split randomly at the **row/session level**, so
+  the same mouse appears in multiple sets (train/val 106, train/test 105, val/test 105 shared mice). This
+  is the optimistic, leakage-prone setting — the same family as the base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,465 recordings (WT 73.8% / HT 26.2%); train 7,393 + val 2,465 merged into 9,858 train rows.
+- **What was adapted vs the base model:** one lever changes — model family (TabPFN instead of XGBoost) —
+  while the dependent evaluation split is held the same, so this isolates the model effect.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.962 | 0.550 | — |
+| Recall | 0.733 | 0.918 | — |
+| F1 | 0.832 | 0.688 | weighted **0.794** |
+| Accuracy | | | **0.781** (train 0.888) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1332, WT→HT 486], [HT→WT 53, HT→HT 594]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.781 | 0.733 | +0.048 |
+| Weighted F1 | 0.794 | 0.749 | +0.045 |
+| WT F1 | 0.832 | 0.785 | +0.047 |
+| HT F1 | 0.688 | 0.649 | +0.039 |
+| HT recall | 0.918 | 0.940 | −0.022 |
+| HT precision | 0.550 | 0.496 | +0.054 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- On the same leaky dependent split, **TabPFN beats the XGBoost base on every aggregate**: accuracy
+  0.781 (+0.048), weighted F1 0.794 (+0.045), and both per-class F1s improve — a clean model-only win.
+- The biggest gain is **HT precision +0.054** (0.550 vs 0.496): false positives drop, so HT F1 rises to
+  0.688 (+0.039) while HT recall stays near-saturated at 0.918 (−0.022, still catching ~92% of ASD pups).
+- Class separation is still the limit — **HT precision is only 0.550**, so nearly half of HT calls remain
+  false positives (486 of WT mislabeled HT in the confusion matrix).
+- Train 0.888 vs test 0.781 (0.11 gap) plus the shared-mouse leakage means these numbers are optimistic;
+  the leak-free read lives in `../tabpfn_subject_eval_independent_baseline/` (~0.73 accuracy there).
+
+## Recommendations
+- Use this run only as an upper-bound, leaky estimate; quote the subject-independent TabPFN run for any
+  honest "new-mouse" claim.
+- HT precision ≈ 0.55 at the default 0.5 cut — the threshold runs (`../threshold/`,
+  `../threshold_objectives/`) can trade some of the spare HT recall for cleaner positive calls.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/tabpfn_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/tabpfn_subject_eval_independent_baseline/README.md
@@ -1,0 +1,62 @@
+# tabpfn_subject_eval_independent_baseline — TabPFN · subject-independent
+
+> TabPFN on the official baseline data, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation set is merged
+  into train, so there is no early-stopping/learning curve).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,139 recordings from 22 held-out mice (WT 72.9% / HT 27.1%).
+- **What was adapted vs the base model:** two levers change together — model family (TabPFN instead of
+  XGBoost) **and** evaluation moves from subject-dependent to subject-independent.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.898 | 0.499 | — |
+| Recall | 0.709 | 0.782 | — |
+| F1 | 0.792 | 0.610 | weighted **0.743** |
+| Accuracy | | | **0.729** (train 0.911) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1106, WT→HT 454], [HT→WT 126, HT→HT 453]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.729 | 0.733 | −0.004 |
+| Weighted F1 | 0.743 | 0.749 | −0.006 |
+| WT F1 | 0.792 | 0.785 | +0.007 |
+| HT F1 | 0.610 | 0.649 | −0.039 |
+| HT recall | 0.782 | 0.940 | −0.158 |
+| HT precision | 0.499 | 0.496 | +0.003 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Despite the **harder leak-free split**, overall accuracy (0.729) and weighted F1 (0.743) land within
+  ~0.005 of the dependent base model — TabPFN largely absorbs the difficulty that usually costs
+  10–15 pts when moving dependent → independent.
+- The operating point shifts conservative on the minority class: **HT recall falls to 0.782** (−0.158
+  vs base) while WT recall rises to 0.709. The model now misses ~1 in 5 ASD-model pups.
+- Class separation is still weak — **HT precision ≈ 0.50** (about half of HT predictions are false
+  positives); HT F1 0.610.
+- Train 0.911 vs test 0.729 (0.18 gap) reflects the cost of unseen mice; TabPFN merges val into train,
+  which inflates the train figure.
+
+## Recommendations
+- HT recall is low at the default 0.5 cut — see the threshold runs (`../threshold/`,
+  `../threshold_objectives/`); for independent splits `target_recall` (~0.80) keeps a controlled
+  operating point.
+- Use this independent run, not the dependent base, for any "new-mouse" performance estimate; but note
+  HT precision remains ~0.50, so positive calls need confirmation.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/threshold/tabpfn_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/threshold/tabpfn_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,87 @@
+# tabpfn_subject_eval_dependent_baseline — TabPFN · subject-dependent · threshold (Youden)
+
+> TabPFN on the official baseline data (subject-dependent split), with a **tuned decision threshold** (Youden J) replacing the default 0.5 cut — no retraining.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning).
+- **Evaluation split:** subject-dependent — train/val/test split **at the row level** (random), so the
+  same mouse appears across sets (train/test share 105 mice). Leaky/optimistic, matching the base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,465 recordings (WT 73.8% / HT 26.2%).
+- **What was adapted vs the base model:** a single lever — **decision-threshold tuning (Youden J)** on
+  top of an already-trained TabPFN. Only the 0.5 cut is replaced by a threshold chosen from **leak-free
+  validation probabilities**; the model is not retrained. Here TabPFN's val set is held **out** (not
+  merged into train) so its probabilities stay leak-free for threshold derivation — this run trains on
+  ~60% of the data vs the 80% of the non-threshold TabPFN run, so the @0.5 numbers differ slightly.
+- See the curated parent summary at [`../README.md`](../README.md).
+
+## Results (test set)
+Tuned threshold = **0.4540** (Youden J, from validation). Val AUC **0.912**, test AUC **0.908**
+(threshold-independent).
+
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.970 | 0.531 | — |
+| Recall | 0.705 | 0.938 | — |
+| F1 | 0.817 | 0.678 | weighted **0.780** |
+| Accuracy | | | **0.766** (train 0.866) |
+
+Confusion matrix @tuned (rows = true, cols = pred): `[[WT→WT 1282, WT→HT 536], [HT→WT 40, HT→HT 607]]`.
+
+**0.5 vs tuned (0.4540) on the test set:**
+| Metric | @0.5 | @tuned | Δ |
+|---|---|---|---|
+| Accuracy | 0.783 | 0.766 | −0.017 |
+| Balanced accuracy | 0.828 | 0.822 | −0.006 |
+| HT recall | 0.921 | 0.938 | +0.017 |
+| HT precision | 0.552 | 0.531 | −0.021 |
+| HT F1 | 0.691 | 0.678 | −0.012 |
+| WT recall | 0.734 | 0.705 | −0.029 |
+| WT precision | 0.963 | 0.970 | +0.007 |
+| WT F1 | 0.833 | 0.817 | −0.017 |
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run (@tuned) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.766 | 0.733 | +0.033 |
+| Weighted F1 | 0.780 | 0.749 | +0.031 |
+| WT F1 | 0.817 | 0.785 | +0.032 |
+| HT F1 | 0.678 | 0.649 | +0.029 |
+| HT recall | 0.938 | 0.940 | −0.002 |
+| HT precision | 0.531 | 0.496 | +0.035 |
+
+*Base model is at its default 0.5 cut; this run is at the tuned 0.4540 threshold.*
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- TabPFN beats the XGBoost base on every headline metric: **+0.033 accuracy, +0.031 weighted F1**, while
+  matching HT recall (0.938 vs 0.940) — so the minority class is caught just as often, with better
+  precision (0.531 vs 0.496) and far fewer WT false positives.
+- Youden tuning here **lowers** the cut (0.4540 < 0.5), trading a bit of accuracy (−0.017) and WT recall
+  (−0.029) for +0.017 HT recall. The model was already HT-aggressive at 0.5; the tuned point pushes
+  slightly further toward catching positives.
+- AUC is strong (test **0.908**), so the model ranks WT vs HT well; the limiting factor is HT precision
+  (~0.53 — about half of HT calls are false positives), which threshold moves cannot fix.
+- Train 0.866 vs test 0.766 (0.10 gap) is modest for a leaky dependent split — but remember this split is
+  optimistic; use the independent runs for honest new-mouse estimates.
+
+## Recommendations
+- The default 0.5 cut already gives higher accuracy (0.783) and balanced accuracy (0.828) than the tuned
+  point; **Youden buys little here** (+0.017 HT recall for −0.017 accuracy). Prefer 0.5 unless maximizing
+  HT recall is the explicit goal.
+- For a controlled HT-recall operating point, see the objective sweep in
+  [`../../threshold_objectives/`](../../threshold_objectives/) (`f1` / `target_recall` ≈ 0.6171 here trade
+  recall for precision).
+
+## Artifacts
+- `plots/roc_curve.png` — ROC (test AUC 0.908). `plots/conf_matrix_thr0.5.png`,
+  `plots/conf_matrix_thr_tuned.png` — confusion matrices at the two cuts.
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — overall + per-strain confusion matrices.
+- `threshold_report.txt`, `threshold_metrics.json` — tuned threshold, candidate cuts, val/test AUC,
+  @0.5-vs-@tuned metrics. `probabilities_val.csv`, `probabilities_test.csv` — raw scores.
+- `model/tabpfn_model.pkl` — fitted TabPFN. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `threshold_metrics.json` + `threshold_report.txt`; `comparison_vs_baseline.txt` (run column only).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` (default 0.5 cut) · metrics from `threshold_metrics.json` + `threshold_report.txt` · summary auto-generated*

--- a/results/tabular_models/threshold/tabpfn_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/threshold/tabpfn_subject_eval_independent_baseline/README.md
@@ -1,0 +1,78 @@
+# tabpfn_subject_eval_independent_baseline — TabPFN · subject-independent · threshold (Youden)
+
+> Youden-J decision threshold applied to the leak-free TabPFN independent run — no retraining, just a new cut.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning). In threshold mode the
+  validation set is **held OUT** (not merged into train), so its probabilities are leak-free for deriving
+  the cut — this run trains on ~60% of the data (7,866 rows) vs the 80% used by the non-threshold TabPFN
+  run, so its @0.5 numbers differ slightly (not a regression).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. The honest "generalize to unseen mice" setting (harder than the dependent
+  base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,139 recordings from 22 held-out mice (WT 72.9% / HT 27.1%).
+- **What was adapted vs the base model:** decision-threshold tuning (Youden's J) — the 0.5 cut is replaced
+  by a threshold chosen from leak-free validation probabilities. **No retraining.** See
+  [`../README.md`](../README.md) for the curated threshold-folder summary.
+
+## Results (test set)
+Tuned threshold (Youden) = **0.0055**; val AUC 0.679, test AUC **0.783** (threshold-independent).
+
+| Metric | @0.5 (default) | @tuned (0.0055) | Δ |
+|---|---|---|---|
+| Accuracy | 0.713 | 0.703 | −0.010 |
+| Balanced accuracy | 0.662 | 0.796 | +0.134 |
+| HT recall | 0.551 | 0.998 | +0.447 |
+| HT precision | 0.474 | 0.477 | +0.003 |
+| HT F1 | 0.510 | 0.645 | +0.136 |
+| WT recall | 0.773 | 0.594 | −0.179 |
+| WT precision | 0.823 | 0.999 | +0.176 |
+| WT F1 | 0.797 | 0.745 | −0.052 |
+
+Confusion matrix @0.5 (rows = true, cols = pred): `[[WT→WT 1206, WT→HT 354], [HT→WT 260, HT→HT 319]]`.
+Confusion matrix @tuned: `[[WT→WT 926, WT→HT 634], [HT→WT 1, HT→HT 578]]` — 578/579 HT caught, only 1 missed.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Comparing this run's **tuned**-threshold test metrics to the base model (base is at its default **0.5** cut).
+
+| Metric | This run (tuned) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.703 | 0.733 | −0.030 |
+| Weighted F1 | 0.718 | 0.749 | −0.031 |
+| WT F1 | 0.745 | 0.785 | −0.040 |
+| HT F1 | 0.645 | 0.649 | −0.004 |
+| HT recall | 0.998 | 0.940 | +0.058 |
+| HT precision | 0.477 | 0.496 | −0.019 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The Youden cut is extreme (**0.0055**): it flips this run into near-total HT detection — **HT recall 0.998**
+  (1 of 579 missed), balanced accuracy jumps +0.134 (0.662 → 0.796) for almost no accuracy cost (−0.010).
+- The trade-off is paid in **WT recall, which collapses to 0.594** (−0.179): 634 of 1,560 WT pups are now
+  flagged HT. HT precision barely moves (0.477), so positive calls are still ~half false alarms.
+- Threshold tuning recovers the recall that the leak-free split had cost the @0.5 operating point, landing
+  HT F1 (0.645) essentially level with the dependent base (0.649, Δ −0.004) — but via the opposite
+  precision/recall mix (high recall, low precision).
+- Class separation is fundamentally weak here: **val AUC is only 0.679** (test AUC 0.783), so the cut is
+  derived from a poorly-separated validation distribution, which is why such a low threshold is needed.
+
+## Recommendations
+- This tuned point is an aggressive **screening** operating mode (catch almost every ASD-model pup, accept
+  many WT false positives). For a controlled balance use `target_recall` (~0.80, threshold 0.0948) — see
+  [`../../threshold_objectives/`](../../threshold_objectives/) for the full objective sweep.
+- Positive (HT) calls still need confirmation: HT precision ≈ 0.48 even after tuning.
+
+## Artifacts
+- `plots/roc_curve.png` — validation ROC with operating points. `plots/conf_matrix_thr0.5.png`,
+  `plots/conf_matrix_thr_tuned.png` — confusion matrices at each cut.
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — overall + per-strain confusion matrices.
+- `model/tabpfn_model.pkl` — fitted TabPFN (~225 MB, gitignored).
+- `probabilities_val.csv` / `probabilities_test.csv` — per-sample P(HT); the val file is the leak-free
+  source the threshold is derived from.
+- Metrics source: `threshold_report.txt` + `threshold_metrics.json`; `logs/out.txt` — flags, split info,
+  class balance.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `threshold_report.txt` + `threshold_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold/xgboost_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/threshold/xgboost_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,82 @@
+# xgboost_subject_eval_dependent_baseline — XGBoost · subject-dependent · threshold (Youden)
+
+> The base XGBoost model with a tuned decision threshold (Youden J) replacing the default 0.5 cut — **no retraining**.
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe), the same fitted model as the base run — this folder only
+  swaps the decision threshold.
+- **What was adapted vs the base model:** decision-threshold tuning only. The 0.5 cut is replaced by a
+  threshold chosen from **leak-free validation probabilities** via Youden's J; the model weights are
+  unchanged (`model/xgboost_model.pkl`).
+- **Evaluation split:** subject-dependent — random row-level split (`logs/out.txt` warns of mouse overlap:
+  106 train/val, 105 train/test shared mice). Optimistic/leaky vs the honest independent setting.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,465 recordings (WT 73.8% / HT 26.2%).
+- **Tuned threshold:** 0.5281 (Youden). Candidates were youden 0.5281, f1 0.6174, target_recall 0.6297,
+  balanced 0.5280. Val AUC 0.891, test AUC 0.876 (threshold-independent).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.957 | 0.499 | — |
+| Recall | 0.673 | 0.915 | — |
+| F1 | 0.790 | 0.646 | weighted **0.753** |
+| Accuracy | | | **0.737** (train 0.782) |
+
+Balanced accuracy 0.794 · test AUC 0.876.
+Confusion matrix @tuned (rows = true, cols = pred): `[[WT→WT 1224, WT→HT 594], [HT→WT 55, HT→HT 592]]`.
+
+**@0.5 (default) vs @tuned (0.5281):**
+| Metric | @0.5 | @tuned | Δ |
+|---|---|---|---|
+| Accuracy | 0.727 | 0.737 | +0.009 |
+| Balanced accuracy | 0.795 | 0.794 | −0.001 |
+| HT recall | 0.937 | 0.915 | −0.022 |
+| HT precision | 0.490 | 0.499 | +0.009 |
+| HT F1 | 0.643 | 0.646 | +0.003 |
+| WT recall | 0.653 | 0.673 | +0.020 |
+| WT precision | 0.967 | 0.957 | −0.010 |
+| WT F1 | 0.779 | 0.790 | +0.011 |
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.737 | 0.733 | +0.004 |
+| Weighted F1 | 0.753 | 0.749 | +0.004 |
+| WT F1 | 0.790 | 0.785 | +0.005 |
+| HT F1 | 0.646 | 0.649 | −0.003 |
+| HT recall | 0.915 | 0.940 | −0.025 |
+| HT precision | 0.499 | 0.496 | +0.003 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+The base model is reported at the default 0.5 cut; this run's Δ uses the **tuned (0.5281)** operating point.
+
+## Key insights
+- The Youden threshold sits just above 0.5 (0.5281), so it barely moves the operating point: the tuned
+  cut buys +0.009 accuracy and +0.011 WT F1 over @0.5 while trading 0.022 of HT recall — a small,
+  near-neutral shift, as expected when validation AUC is high (0.891) and the data is class-imbalanced.
+- Balanced accuracy is essentially flat (0.795 → 0.794): for this already-recall-heavy model, Youden has
+  little left to optimize. The win is almost entirely on the majority class (WT recall 0.653 → 0.673).
+- Versus the base 0.5-cut model the gains are marginal (+0.004 accuracy, +0.004 weighted F1) and HT
+  recall actually drops 0.025 — the threshold cannot fix the core weakness: **HT precision stays ≈ 0.50**,
+  so half of all HT calls remain false positives.
+
+## Recommendations
+- Youden gives almost nothing here. If the goal is fewer false alarms, the `f1`/`balanced` thresholds
+  (~0.62) are higher — see the cross-objective runs in `../../threshold_objectives/` for the full sweep.
+- This is a dependent (leaky) run; do not quote it as generalization. Use the independent threshold run
+  for any new-mouse estimate.
+
+## Artifacts
+- `plots/roc_curve.png` — ROC with the tuned operating point. `plots/conf_matrix_thr0.5.png` and
+  `plots/conf_matrix_thr_tuned.png` — confusion matrices at each cut.
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+  `plots/AUC_error.png`, `plots/feature_importance_1.png`, `plots/feature_importances_0.png`.
+- `model/xgboost_model.pkl` — the (unchanged) fitted model. `probabilities_val.csv`,
+  `probabilities_test.csv` — per-recording probabilities the threshold was derived/applied on.
+- Metrics source: `threshold_metrics.json`, `threshold_report.txt`, `comparison_vs_baseline.txt`
+  (run column only), `logs/out.txt`. Parent summary: `../README.md`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `threshold_metrics.json` + `threshold_report.txt` + `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/threshold/xgboost_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/threshold/xgboost_subject_eval_independent_baseline/README.md
@@ -1,0 +1,82 @@
+# xgboost_subject_eval_independent_baseline — XGBoost · subject-independent · threshold (Youden)
+
+> Decision-threshold tuning (Youden J) on the leak-free independent XGBoost model — no retraining, only the 0.5 cut is replaced.
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe). This run does **not** retrain — it takes the already-fitted
+  independent model and replaces the default 0.5 decision cut with a threshold chosen from leak-free
+  **validation** probabilities (Youden J).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware on `mouse_idx`), so no mouse appears in two sets. This is the honest "generalize to unseen
+  mice" setting (harder than the dependent base model, which splits rows randomly and lets mice leak
+  across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,139 recordings from 22 held-out mice (WT 72.9% / HT 27.1%); val = 2,318 rows from 21 mice.
+- **What was adapted vs the base model:** decision-threshold tuning only — the operating point moves from
+  0.5 to **0.1280** (Youden), and evaluation moves from subject-dependent to subject-independent. No
+  hyperparameters change.
+
+## Results (test set)
+Tuned threshold = **0.1280** (Youden J, val-derived). Validation AUC 0.691 / **test AUC 0.770**
+(threshold-independent).
+
+| Metric | @0.5 (default) | @tuned (0.1280) | Δ |
+|---|---|---|---|
+| Accuracy | 0.692 | 0.705 | +0.013 |
+| Balanced accuracy | 0.678 | 0.797 | +0.119 |
+| HT recall | 0.646 | 0.998 | +0.352 |
+| HT precision | 0.452 | 0.478 | +0.026 |
+| HT F1 | 0.532 | 0.647 | +0.115 |
+| WT recall | 0.710 | 0.596 | −0.113 |
+| WT precision | 0.844 | 0.999 | +0.155 |
+| WT F1 | 0.771 | 0.747 | −0.024 |
+
+Confusion matrix @tuned (rows = true, cols = pred): `[[WT→WT 930, WT→HT 630], [HT→WT 1, HT→HT 578]]`
+(vs @0.5: `[[1107, 453], [205, 374]]`).
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run (tuned) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.705 | 0.733 | −0.028 |
+| Weighted F1 | 0.720 | 0.749 | −0.029 |
+| WT F1 | 0.747 | 0.785 | −0.038 |
+| HT F1 | 0.647 | 0.649 | −0.002 |
+| HT recall | 0.998 | 0.940 | +0.058 |
+| HT precision | 0.478 | 0.496 | −0.018 |
+
+The base model is at its default 0.5 cut; this run's column is the **tuned** 0.1280 operating point.
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The tuned threshold is a strong **recall-maximizing** move: dropping the cut from 0.5 to 0.1280 lifts
+  HT recall from 0.646 to **0.998** (+0.352) and balanced accuracy from 0.678 to **0.797** (+0.119) —
+  only 1 of 579 ASD-model pups is missed.
+- That recall is bought with WT cost: WT recall falls to 0.596 (630 WT calls flipped to HT), so **HT
+  precision stays ≈ 0.48** — roughly half of HT predictions are still false positives. The cut trades WT
+  false negatives for WT false positives rather than improving separation.
+- Class separation is genuinely modest: **test AUC 0.770** with **val AUC only 0.691**, so the threshold
+  is tuned on a weaker val signal — expect the operating point to be slightly optimistic on test.
+- vs the dependent base, the tuned run lands ~0.03 below on accuracy/weighted F1 (the honest
+  independent penalty), but matches HT F1 (0.647 vs 0.649) while pushing HT recall above base (0.998 vs
+  0.940) — a near-complete-coverage operating point for the minority class.
+
+## Recommendations
+- Use this run when **catching every ASD-model pup matters more than false alarms** (HT recall 0.998);
+  for a balanced operating point with controlled WT loss, prefer the `target_recall` candidate (0.4392,
+  HT recall ≥ 0.80) from `threshold_report.txt` or compare across `../threshold_objectives/`.
+- Positive (HT) calls still need confirmation — HT precision ≈ 0.48 — so do not treat an HT prediction
+  as a diagnosis at this threshold.
+- See the curated parent summary at [`../README.md`](../README.md) for the cross-objective threshold picture.
+
+## Artifacts
+- `plots/roc_curve.png` — ROC + AUC. `plots/conf_matrix_thr0.5.png` / `plots/conf_matrix_thr_tuned.png`
+  — confusion matrices at the default and tuned cuts; `plots/conf_matrix.png`,
+  `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`, `plots/confusionmatrix_strain2.png`
+  (overall + per strain); `plots/AUC_error.png`, `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png`.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance,
+  applied threshold. `probabilities_val.csv` / `probabilities_test.csv` — raw scores.
+- Metrics source: `threshold_report.txt` + `threshold_metrics.json` (`comparison_vs_baseline.txt` run column only).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `threshold_report.txt` + `threshold_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold/xgboost_tuned_dependent_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/threshold/xgboost_tuned_dependent_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,84 @@
+# xgboost_tuned_dependent_subject_eval_dependent_baseline — XGBoost (tuned) · subject-dependent · threshold (Youden)
+
+> Tuned XGBoost on the baseline data with a **Youden-J decision threshold** (0.366) swapped in for the default 0.5 cut — no retraining.
+
+## Overview
+- **Model:** XGBoost, dependent-tuned recipe (`xgboost_tuned_dependent`; hyperparameters from a 200-trial
+  random search tuned for the dependent split). Same fitted model as the base run — only the decision
+  cut changes.
+- **What was adapted vs the base model:** decision-threshold tuning only. The Youden-J point that
+  maximizes balanced accuracy is selected from **leak-free validation probabilities** and applied at
+  test time. No weights are re-fit; the 0.5 cut is replaced by **0.366**.
+- **Evaluation split:** subject-dependent — random row-level split (`--baseline`), so the same mouse can
+  appear in train, val and test (logged overlap: 105 shared mice train/test). Optimistic by design,
+  matching the base model's setting.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,465 recordings (WT 73.8% / HT 26.2%).
+- **Threshold-independent ranking:** validation AUC 0.896, test AUC 0.885.
+
+## Results (test set)
+Tuned operating point (Youden = 0.366):
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.972 | 0.493 | — |
+| Recall | 0.653 | 0.947 | — |
+| F1 | 0.782 | 0.649 | weighted **0.747** |
+| Accuracy | | | **0.731** (train 0.801, balanced 0.800) |
+
+Confusion matrix @tuned (rows = true, cols = pred): `[[WT→WT 1188, WT→HT 630], [HT→WT 34, HT→HT 613]]`.
+
+**0.5 vs tuned (0.366), test set:**
+| Metric | @0.5 | @tuned | Δ |
+|---|---|---|---|
+| Accuracy | 0.771 | 0.731 | −0.040 |
+| Balanced accuracy | 0.798 | 0.800 | +0.002 |
+| HT recall | 0.856 | 0.947 | +0.091 |
+| HT precision | 0.540 | 0.493 | −0.047 |
+| HT F1 | 0.662 | 0.649 | −0.014 |
+| WT recall | 0.740 | 0.653 | −0.087 |
+| WT precision | 0.935 | 0.972 | +0.037 |
+| WT F1 | 0.827 | 0.782 | −0.045 |
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run (tuned) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.731 | 0.733 | −0.002 |
+| Weighted F1 | 0.747 | 0.749 | −0.002 |
+| WT F1 | 0.782 | 0.785 | −0.003 |
+| HT F1 | 0.649 | 0.649 | +0.000 |
+| HT recall | 0.947 | 0.940 | +0.007 |
+| HT precision | 0.493 | 0.496 | −0.003 |
+
+*Base model is reported at the default 0.5 cut; this run's column uses the tuned 0.366 threshold.*
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The Youden cut (0.366) lands almost exactly where the untuned base model already sits: HT recall 0.947
+  (+0.007) and HT F1 0.649 (+0.000) are effectively tied with base, so tuning the threshold buys nothing
+  versus the base operating point on this dependent split.
+- The real trade is **0.5 → tuned within this model**: dropping the cut to 0.366 lifts HT recall
+  0.856 → 0.947 (+0.091) but cuts HT precision 0.540 → 0.493 and overall accuracy 0.771 → 0.731.
+  Balanced accuracy barely moves (0.798 → 0.800), confirming the curve is flat near the optimum.
+- Class separation stays weak — **HT precision ≈ 0.49** at the tuned cut (about half of HT predictions are
+  false positives; 630 WT recordings flagged HT). AUC 0.885 caps what any threshold can deliver.
+- Train 0.801 vs test 0.731 is a modest gap; the dependent split leaks mice across sets, so even this
+  number is optimistic relative to a leak-free estimate.
+
+## Recommendations
+- The default-0.5 base model already matches this tuned point — keep the threshold tuning only if you
+  specifically want the +0.091 HT-recall lift, and accept the precision/accuracy cost.
+- For an honest "new-mouse" estimate use an independent run, not this dependent one; for a controlled
+  operating point see the `target_recall` candidate (0.547, HT recall ≥ 0.80) in `threshold_report.txt`.
+
+## Artifacts
+- `plots/roc_curve.png` — ROC with the tuned operating point. `plots/conf_matrix_thr0.5.png` /
+  `plots/conf_matrix_thr_tuned.png` — confusion matrices at each cut.
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — overall + per-strain matrices.
+- `plots/AUC_error.png` — learning curve. `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_tuned_dependent_model.pkl` — fitted model. `probabilities_val.csv` /
+  `probabilities_test.csv` — per-recording probabilities used for threshold selection.
+- Metrics source: `threshold_report.txt`, `threshold_metrics.json`, `logs/out.txt`. Parent summary: `../README.md`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` (default 0.5 cut) · metrics from `threshold_report.txt` + `threshold_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold/xgboost_tuned_independent_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/threshold/xgboost_tuned_independent_subject_eval_independent_baseline/README.md
@@ -1,0 +1,75 @@
+# xgboost_tuned_independent_subject_eval_independent_baseline — XGBoost (tuned) · subject-independent · threshold (Youden)
+
+> Tuned independent XGBoost on the baseline data, leak-free split, with the 0.5 cut replaced by a Youden-J threshold from validation probabilities.
+
+## Overview
+- **Model:** `xgboost_tuned_independent` — XGBoost with hyperparameters from a 200-trial random search
+  tuned for the independent split (heavily regularized / shallow). Class balance handled via
+  `scale_pos_weight=3.07`.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`,
+  group-aware on `mouse_idx`), so no mouse appears in two sets. Honest "generalize to unseen mice"
+  setting (harder than the dependent base model, which splits rows randomly and lets mice leak).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,139 recordings from 22 held-out mice (WT 72.9% / HT 27.1%).
+- **What was adapted vs the base model:** **decision-threshold tuning only** — no retraining. The 0.5
+  cut is replaced by the Youden-J threshold (0.288) chosen from leak-free **validation** probabilities;
+  the underlying split also moves dependent → independent.
+
+## Results (test set)
+Tuned threshold = **0.288** (Youden J). Val AUC 0.641 / test AUC 0.753 (threshold-independent).
+
+@0.5 (default) vs @tuned:
+| Metric | @0.5 | @tuned | Δ |
+|---|---|---|---|
+| Accuracy | 0.695 | 0.704 | +0.008 |
+| Balanced accuracy | 0.725 | 0.797 | +0.071 |
+| HT recall | 0.791 | 1.000 | +0.209 |
+| HT precision | 0.463 | 0.477 | +0.014 |
+| HT F1 | 0.584 | 0.646 | +0.062 |
+| WT recall | 0.660 | 0.594 | −0.066 |
+| WT precision | 0.895 | 1.000 | +0.105 |
+| WT F1 | 0.759 | 0.745 | −0.014 |
+
+Per-class @tuned: WT precision 1.000 / recall 0.594 / F1 0.745; HT precision 0.477 / recall 1.000 /
+F1 0.646; weighted F1 **0.718**; accuracy **0.704** (train 0.678).
+
+Confusion matrix @tuned (rows = true, cols = pred): `[[WT→WT 926, WT→HT 634], [HT→WT 0, HT→HT 579]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Base is at its default 0.5 cut; this run is at the tuned 0.288 cut.
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.704 | 0.733 | −0.029 |
+| Weighted F1 | 0.718 | 0.749 | −0.031 |
+| WT F1 | 0.745 | 0.785 | −0.040 |
+| HT F1 | 0.646 | 0.649 | −0.003 |
+| HT recall | 1.000 | 0.940 | +0.060 |
+| HT precision | 0.477 | 0.496 | −0.019 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The tuned threshold trades WT recall for total HT recall: **HT recall hits 1.000** (every ASD-model pup
+  caught, +0.209 over the 0.5 cut), lifting balanced accuracy from 0.725 to 0.797 — but **HT precision
+  stays ~0.48**, so the model now predicts HT for 634 of 1,560 true-WT recordings.
+- This is a near-degenerate operating point on the positive class: zero HT misses (0 in the HT→WT cell)
+  comes only because the cut is low; HT F1 (0.646) is barely above base (−0.003) despite perfect recall.
+- AUC is the real ceiling here — **test AUC 0.753** vs **val AUC 0.641**. The low val AUC means the
+  Youden cut is tuned on weakly-separated validation probabilities, which is why it lands so aggressive.
+- Threshold tuning recovers most of the accuracy gap that the leak-free split opens (−0.029 vs base at
+  tuned, vs the −0.125 legacy reference in the comparison file), but cannot fix class separation.
+
+## Artifacts
+- `plots/roc_curve.png` — ROC (test AUC 0.753). `plots/conf_matrix_thr0.5.png`,
+  `plots/conf_matrix_thr_tuned.png` — confusion matrices at each cut.
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importance.
+- `model/xgboost_tuned_independent_model.pkl` — fitted model (threshold applied post-hoc, no retrain).
+- `threshold_report.txt`, `threshold_metrics.json` — candidate thresholds + 0.5-vs-tuned metrics.
+- `probabilities_val.csv`, `probabilities_test.csv` — per-recording probabilities.
+- `logs/out.txt` — flags, split info, class balance. Parent summary: [`../README.md`](../README.md).
+- Metrics source: `threshold_metrics.json` + `threshold_report.txt` + `comparison_vs_baseline.txt` (run column only).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `threshold_metrics.json` + `threshold_report.txt` · summary auto-generated*

--- a/results/tabular_models/threshold_objectives/tabpfn_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/threshold_objectives/tabpfn_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,69 @@
+# tabpfn_subject_eval_dependent_baseline — TabPFN · subject-dependent · threshold objectives
+
+> Re-derives the decision threshold for the dependent TabPFN run under four objectives — **same model, no retraining**.
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation merged into
+  train). Identical fitted model as the dependent base TabPFN run.
+- **Evaluation split:** subject-dependent — train/val/test split by **row/session** (same mouse can
+  appear in train and test). Optimistic vs the leak-free independent setting.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). Val labels
+  WT=1865 / HT=600; test support WT=1818 / HT=647. Val AUC 0.912, test AUC 0.908.
+- **What was adapted vs the base model:** decision-threshold **objective selection only** — the cut is
+  re-derived from saved validation probabilities under youden / f1 / target_recall / balanced, plus the
+  0.5 default. No weights, features, or training change.
+- **Recommended objective:** **f1** for dependent splits (target_recall is the pick for independent
+  splits). Here f1 and target_recall land on the **same threshold 0.617** because the f1-optimal cut
+  already satisfies the 0.80 HT-recall floor.
+
+## Results (test set)
+Per-objective performance at each derived threshold (AUC is threshold-invariant at 0.908):
+
+| Objective | thr | Acc | BalAcc | HT rec | HT prec | HT F1 | WT rec |
+|---|---|---|---|---|---|---|---|
+| @0.5 | 0.500 | 0.783 | 0.828 | 0.921 | 0.552 | 0.691 | 0.734 |
+| youden | 0.454 | 0.766 | 0.822 | 0.938 | 0.531 | 0.678 | 0.705 |
+| **f1** (recommended) | 0.617 | **0.819** | 0.817 | 0.811 | 0.619 | **0.702** | 0.822 |
+| target_recall | 0.617 | 0.819 | 0.817 | 0.811 | 0.619 | 0.702 | 0.822 |
+| balanced | 0.453 | 0.766 | 0.821 | 0.938 | 0.531 | 0.678 | 0.705 |
+
+f1 confusion matrix (rows = true, cols = pred): `[[WT→WT 1495, WT→HT 323], [HT→WT 122, HT→HT 525]]`.
+target_recall floor = HT recall ≥ 0.80.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Recommended **f1** objective (thr 0.617) vs base at its 0.5 cut:
+
+| Metric | This run (f1) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.819 | 0.733 | +0.086 |
+| Weighted F1 | 0.826 | 0.749 | +0.077 |
+| WT F1 | 0.870 | 0.785 | +0.085 |
+| HT F1 | 0.702 | 0.649 | +0.053 |
+| HT recall | 0.811 | 0.940 | −0.129 |
+| HT precision | 0.619 | 0.496 | +0.123 |
+
+## Key insights
+- Raising the cut to **0.617** trades minority recall for balance: HT recall drops to 0.811 (−0.129 vs
+  base) but HT **precision climbs to 0.619** (+0.123) — far fewer false ASD-model calls (483→323 WT
+  misfires at default, vs base's recall-heavy 0.5 operating point).
+- The f1 cut beats the base model on every aggregate metric — accuracy +0.086, weighted F1 +0.077,
+  HT F1 +0.053 — while keeping HT recall above the 0.80 floor; this is the strongest dependent operating
+  point in the threshold sweep.
+- youden and balanced collapse to the recall-greedy end (thr ≈0.45, HT recall 0.938, HT precision 0.531),
+  essentially reproducing the base model's behavior and adding nothing over the 0.5 default.
+- All numbers are threshold re-reads of one fixed TabPFN model (test AUC 0.908) — the gains are pure
+  operating-point selection, not better discrimination.
+
+## Recommendations
+- Ship the **f1 threshold (0.617)** for dependent-split deployment: best balance of HT recall (0.811)
+  and precision (0.619). Avoid youden/balanced here — they only inflate false positives.
+- For honest new-mouse estimates use the independent run with `target_recall`; see `../README.md` for the
+  cross-run objective summary (`summary_objectives.txt`).
+
+## Artifacts
+- `objective_comparison.txt` — per-objective thresholds, test metrics, and confusion matrices (table source).
+- `objective_metrics.json` — full per-objective per-class precision/recall/F1, support, AUC, thresholds, diagnostics.
+- Probabilities source: `results/tabular_models/threshold/tabpfn_subject_eval_dependent_baseline/probabilities_*.csv` (no model file re-saved; thresholds re-derived).
+- Cross-run rollup: `../summary_objectives.txt`, `../summary_objectives.csv`, `../README.md`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `objective_comparison.txt` + `objective_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold_objectives/tabpfn_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/threshold_objectives/tabpfn_subject_eval_independent_baseline/README.md
@@ -1,0 +1,63 @@
+# tabpfn_subject_eval_independent_baseline — TabPFN · subject-independent · threshold objectives
+
+> Same TabPFN model, leak-free split — the decision threshold is re-derived under four objectives from saved validation probabilities (no retraining).
+
+## Overview
+- **Model:** TabPFN (prior-data-fitted transformer; no hyperparameter tuning; validation merged into
+  train). The fitted model is **identical** to the base TabPFN independent run — only the cut point moves.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets (the honest "generalize to unseen mice" setting).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction). Test = 2,139
+  recordings (WT 1,560 / HT 579); validation labels WT 1,788 / HT 530.
+- **What was adapted vs the base model:** decision-threshold objective selection only. From the saved
+  validation probabilities the threshold is re-derived under `youden`, `f1`, `target_recall` (HT recall
+  floor 0.80) and `balanced`, alongside the 0.5 default. **For this independent split the recommended
+  objective is `target_recall` (~0.80).** Val AUC 0.679, test AUC 0.783 (unchanged by thresholding).
+
+## Results (test set)
+| Objective | thr | acc | balacc | HT rec | HT prec | HT F1 | WT rec |
+|---|---|---|---|---|---|---|---|
+| @0.5 | 0.500 | 0.713 | 0.662 | 0.551 | 0.474 | 0.510 | 0.773 |
+| youden | 0.005 | 0.703 | 0.796 | 0.998 | 0.477 | 0.645 | 0.594 |
+| f1 | 0.005 | 0.703 | 0.796 | 0.998 | 0.477 | 0.645 | 0.594 |
+| **target_recall** | 0.095 | 0.687 | 0.742 | 0.864 | 0.458 | 0.599 | 0.621 |
+| balanced | 0.005 | 0.704 | 0.797 | 1.000 | 0.477 | 0.646 | 0.594 |
+
+`target_recall` confusion matrix (rows = true, cols = pred): `[[WT→WT 969, WT→HT 591], [HT→WT 79, HT→HT 500]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Recommended objective (`target_recall`) on test vs the base model at its 0.5 cut:
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.687 | 0.733 | −0.046 |
+| Weighted F1 | 0.704 | 0.749 | −0.045 |
+| WT F1 | 0.743 | 0.785 | −0.042 |
+| HT F1 | 0.599 | 0.649 | −0.050 |
+| HT recall | 0.864 | 0.940 | −0.076 |
+| HT precision | 0.458 | 0.496 | −0.038 |
+
+## Key insights
+- The default 0.5 cut is far too high for this model: probabilities are crushed toward 0, so every
+  re-derived threshold lands at ~0.005–0.095. At 0.5, HT recall is only 0.551 (HT F1 0.510); any
+  objective threshold roughly **doubles balanced accuracy's lift** (0.662 → 0.74–0.80).
+- `youden`/`f1`/`balanced` all collapse to ~0.005 and predict HT for nearly everyone (HT recall
+  0.998–1.000, WT recall 0.594) — high balanced accuracy but operationally degenerate.
+- `target_recall` (thr 0.095) is the only non-degenerate operating point: HT recall 0.864 with WT recall
+  held at 0.621, balanced accuracy 0.742. It trades raw accuracy (0.687) for a controlled, recall-floored
+  cut — appropriate for the leak-free independent split.
+- HT precision stays ~0.46–0.48 across every objective: class separation is weak (val AUC 0.679), so
+  thresholding moves the recall/precision balance but cannot fix the false-positive rate.
+
+## Recommendations
+- For this independent run use the **`target_recall`** cut (thr ≈ 0.095): HT recall 0.864 without the
+  predict-everything-HT collapse of `youden`/`f1`/`balanced`. Treat the latter three as diagnostic only.
+- Because HT precision remains ~0.46, positive calls still need confirmation regardless of objective.
+
+## Artifacts
+- `objective_comparison.txt` — per-objective thresholds, test metrics, and confusion matrices.
+- `objective_metrics.json` — machine-readable per-objective metrics (per-class precision/recall/F1,
+  supports, confusion matrices, AUC).
+- Probabilities source: `../../threshold/tabpfn_subject_eval_independent_baseline/probabilities_*.csv`.
+- Model context and base TabPFN independent run: [`../README.md`](../README.md).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` (0.5 cut) · metrics from `objective_comparison.txt` + `objective_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold_objectives/xgboost_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/threshold_objectives/xgboost_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,61 @@
+# xgboost_subject_eval_dependent_baseline — XGBoost · subject-dependent · threshold objectives
+
+> Re-derive the XGBoost decision threshold under four objectives (no retraining), same model as the base.
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe) — **identical** to the base model; this run only re-derives
+  the decision threshold from saved validation probabilities. No retraining.
+- **Evaluation split:** subject-dependent — rows split randomly, so the same mouse can appear in train and
+  test (leakage; optimistic). Same split as the base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Val labels WT 1865 / HT 600; test 2,465 recordings (WT 1818 / HT 647). Val AUC 0.891, test AUC 0.876.
+- **What was adapted vs the base model:** decision-threshold objective selection only. Four objectives —
+  `youden`, `f1`, `target_recall` (HT recall floor 0.80), `balanced` — are compared against the 0.5
+  default. **Recommended objective for a dependent split: `f1`.**
+
+## Results (test set)
+| Objective | thr | Acc | BalAcc | HT rec | HT prec | HT F1 | WT rec |
+|---|---|---|---|---|---|---|---|
+| @0.5 | 0.500 | 0.727 | 0.795 | 0.937 | 0.490 | 0.643 | 0.653 |
+| youden | 0.528 | 0.737 | 0.794 | 0.915 | 0.499 | 0.646 | 0.673 |
+| **f1** | 0.617 | **0.767** | 0.774 | 0.788 | 0.538 | 0.639 | 0.759 |
+| target_recall | 0.630 | 0.778 | 0.776 | 0.771 | 0.555 | 0.646 | 0.780 |
+| balanced | 0.528 | 0.736 | 0.794 | 0.915 | 0.499 | 0.646 | 0.673 |
+
+Confusion matrix at `f1` (rows = true, cols = pred): `[[WT→WT 1380, WT→HT 438], [HT→WT 137, HT→HT 510]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Recommended `f1` objective vs base (base is at the 0.5 cut):
+| Metric | This run (`f1`) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.767 | 0.733 | +0.034 |
+| Weighted F1 | 0.778 | 0.749 | +0.029 |
+| WT F1 | 0.828 | 0.785 | +0.043 |
+| HT F1 | 0.639 | 0.649 | −0.010 |
+| HT recall | 0.788 | 0.940 | −0.152 |
+| HT precision | 0.538 | 0.496 | +0.042 |
+
+## Key insights
+- Raising the cut to 0.617 (the `f1` objective) trades minority recall for overall quality: **HT recall
+  drops to 0.788** (−0.152) but **HT precision climbs to 0.538** (+0.042) and accuracy reaches 0.767
+  (+0.034). HT F1 is essentially unchanged (−0.010) — the model just stops over-calling HT.
+- The base 0.5 cut is degenerate-leaning toward the minority: HT recall 0.937 with HT precision 0.490
+  means ~1 in 2 HT calls is a false positive. Every higher-threshold objective fixes precision.
+- `youden` and `balanced` land at nearly the same threshold (0.528) and metrics — both barely move off the
+  0.5 default. Only `f1` and `target_recall` (0.617 / 0.630) meaningfully shift the operating point.
+- Balanced accuracy is best at the 0.5/youden/balanced cuts (~0.795) and dips slightly at `f1` (0.774);
+  the gain there is in plain accuracy and minority precision, not in class-balanced separation.
+
+## Recommendations
+- Use the **`f1`** threshold (0.617) for this dependent split: best accuracy/precision balance with no
+  retraining. If missing ASD-model pups is the dominant cost, prefer `target_recall` — note it still only
+  reaches HT recall 0.771 on test (below its 0.80 val floor) because the dependent test set is harder.
+- For the leak-free independent split, prefer `target_recall` (~0.80) instead; see `../README.md`.
+
+## Artifacts
+- `objective_comparison.txt` — per-objective thresholds, test metrics, and confusion matrices.
+- `objective_metrics.json` — full per-objective per-class metrics + thresholds (machine-readable).
+- Metrics source: `objective_comparison.txt` + `objective_metrics.json`.
+- Threshold methodology and cross-objective context: `../README.md`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `objective_comparison.txt` + `objective_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold_objectives/xgboost_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/threshold_objectives/xgboost_subject_eval_independent_baseline/README.md
@@ -1,0 +1,65 @@
+# xgboost_subject_eval_independent_baseline — XGBoost · subject-independent · threshold-objective sweep
+
+> Re-derives the XGBoost decision threshold under four objectives on the **leak-free** (by-mouse) split — same model, no retraining.
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe), the identical fitted model from the
+  subject-independent base run — only the decision threshold is changed.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. Honest "generalize to unseen mice" setting (harder than the dependent base
+  model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,139 recordings (WT 1,560 / HT 579); validation labels WT 1,788 / HT 530.
+- **What was adapted vs the base model:** decision-threshold objective selection only — no feature,
+  model, or split change. Five operating points are scored: the 0.5 default plus four thresholds picked
+  from **saved validation probabilities** under `youden`, `f1`, `target_recall` (HT-recall floor 0.80),
+  and `balanced`. **Recommended objective for this independent split: `target_recall` (thr 0.439).**
+
+## Results (test set)
+Per-objective metrics on test (AUC fixed at 0.770; same model throughout):
+```
+Objective       thr     acc  balacc   HTrec  HTprec    HTf1   WTrec
+@0.5          0.500   0.692   0.678   0.646   0.452   0.532   0.710
+youden        0.128   0.705   0.797   0.998   0.478   0.647   0.596
+f1            0.128   0.705   0.797   0.998   0.478   0.647   0.596
+target_recall 0.439   0.704   0.728   0.779   0.472   0.588   0.676
+balanced      0.086   0.704   0.796   0.998   0.477   0.646   0.594
+```
+Recommended `target_recall` confusion matrix (rows = true, cols = pred): `[[WT→WT 1055, WT→HT 505], [HT→WT 128, HT→HT 451]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Recommended objective (`target_recall`, thr 0.439) vs base (0.5 cut):
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.704 | 0.733 | −0.029 |
+| Weighted F1 | 0.720 | 0.749 | −0.029 |
+| WT F1 | 0.769 | 0.785 | −0.016 |
+| HT F1 | 0.588 | 0.649 | −0.061 |
+| HT recall | 0.779 | 0.940 | −0.161 |
+| HT precision | 0.472 | 0.496 | −0.024 |
+
+See the parent sweep [`../README.md`](../README.md) for the cross-run objective comparison.
+
+## Key insights
+- **`youden`, `f1`, and `balanced` all collapse to a near-degenerate operating point** (thr 0.086–0.128):
+  HT recall 0.998 with only 1 of 579 HT misses, but WT recall drops to ~0.59 — the model labels HT for
+  almost everyone. They post the best balanced accuracy (~0.797) by sacrificing the majority class.
+- **`target_recall` (thr 0.439) is the only controlled point:** HT recall 0.779 (near the 0.80 floor),
+  WT recall 0.676, balanced accuracy 0.728 — a genuine trade rather than a collapse.
+- Even at the recommended cut the run trails the dependent base on every metric (HT recall −0.161,
+  HT F1 −0.061), reflecting the honest cost of unseen mice; the base's strong HT recall (0.940) is partly
+  a leakage artifact of the dependent split.
+- Class separation stays weak under the leak-free split — **HT precision ≈ 0.47** at every objective
+  (validation AUC only 0.691), so roughly half of HT calls are false positives regardless of threshold.
+
+## Recommendations
+- Use `target_recall` (thr 0.439) for this independent split — the other three objectives are
+  effectively degenerate (predict HT for nearly all mice) and not deployable.
+- Treat any HT prediction as low-confidence (precision ≈ 0.47) and confirm before acting.
+
+## Artifacts
+- `objective_comparison.txt` — human-readable per-objective table + test confusion matrices.
+- `objective_metrics.json` — full per-objective metrics, thresholds, and diagnostics.
+- Source probabilities: `../../threshold/xgboost_subject_eval_independent_baseline/probabilities_*.csv`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `objective_metrics.json` + `objective_comparison.txt` · summary auto-generated*

--- a/results/tabular_models/threshold_objectives/xgboost_tuned_dependent_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/threshold_objectives/xgboost_tuned_dependent_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,64 @@
+# xgboost_tuned_dependent_subject_eval_dependent_baseline — XGBoost (tuned) · subject-dependent · threshold objectives
+
+> Re-deriving the XGBoost-tuned decision threshold under four objectives from saved validation probabilities — same model, no retraining.
+
+## Overview
+- **Model:** XGBoost with the tuned hyperparameters from the 200-trial random search for the **dependent**
+  split. No retraining here — thresholds are re-derived from stored validation probabilities.
+- **Evaluation split:** subject-dependent — train/val/test split by row/session, so the same mouse can
+  appear in train and test (leakage → optimistic; the honest leak-free numbers live in the independent runs).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Validation prob set: WT 1865 / HT 600; test support WT 1818 / HT 647. Val AUC 0.895, test AUC 0.885.
+- **What was adapted vs the base model:** decision-threshold objective selection only — the classifier and
+  features are unchanged. Four objectives (`youden`, `f1`, `target_recall` ~0.80, `balanced`) plus the 0.5
+  default are compared. For a **dependent** split the recommended objective is **`f1`** (`target_recall`
+  is the pick for independent splits, not this one).
+
+## Results (test set)
+| Objective | thr | acc | balacc | HT rec | HT prec | HT F1 | WT rec |
+|---|---|---|---|---|---|---|---|
+| @0.5 | 0.500 | 0.771 | 0.798 | 0.856 | 0.540 | 0.662 | 0.740 |
+| youden | 0.366 | 0.731 | 0.800 | 0.947 | 0.493 | 0.649 | 0.653 |
+| **f1** | **0.568** | **0.789** | **0.787** | **0.784** | **0.572** | **0.661** | **0.791** |
+| target_recall | 0.547 | 0.785 | 0.792 | 0.808 | 0.562 | 0.663 | 0.776 |
+| balanced | 0.365 | 0.731 | 0.800 | 0.947 | 0.493 | 0.649 | 0.653 |
+
+`target_recall` uses an HT recall floor of 0.80; `youden` and `balanced` collapse to the same low cut (0.366/0.365).
+Recommended-objective (`f1`) confusion matrix (rows = true, cols = pred): `[[WT→WT 1438, WT→HT 380], [HT→WT 140, HT→HT 507]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Recommended objective (`f1`, thr 0.568) vs base at its 0.5 cut.
+| Metric | This run (f1) | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.789 | 0.733 | +0.056 |
+| Weighted F1 | 0.798 | 0.749 | +0.049 |
+| WT F1 | 0.847 | 0.785 | +0.062 |
+| HT F1 | 0.661 | 0.649 | +0.012 |
+| HT recall | 0.784 | 0.940 | −0.156 |
+| HT precision | 0.572 | 0.496 | +0.076 |
+
+## Key insights
+- At the `f1` cut the tuned model is a clean accuracy/precision win — test accuracy 0.789 (+0.056) and
+  HT precision 0.572 (+0.076) vs base — by trading away HT recall (0.784, −0.156); it no longer flags
+  almost every pup as HT the way the base 0.5 model does.
+- The objective spread is wide: `youden`/`balanced` push HT recall to 0.947 but drop HT precision to
+  0.493 and overall accuracy to 0.731, while `f1`/`target_recall` raise the cut (~0.55–0.57) for a more
+  balanced operating point. Balanced accuracy is nearly flat across all five (0.787–0.800).
+- HT F1 barely moves across objectives (0.649–0.663) — re-thresholding redistributes recall vs precision
+  but cannot manufacture class separation beyond the fixed AUC (test 0.885).
+- `target_recall` lands at HT recall 0.808 (just above its 0.80 floor) with accuracy 0.785 — a sensible
+  middle ground if missing ~1 in 5 HT pups (the `f1` operating point) is too costly.
+
+## Recommendations
+- For this dependent split use the **`f1`** threshold (0.568): best accuracy/weighted-F1 with HT
+  precision lifted to 0.572. If HT recall matters more than precision, switch to `target_recall` (0.808
+  recall at 0.785 accuracy); avoid `youden`/`balanced` here — they sacrifice ~6 pts of accuracy for recall.
+
+## Artifacts
+- `objective_comparison.txt` — human-readable per-objective table + thresholds + test confusion matrices.
+- `objective_metrics.json` — full per-objective metrics (accuracy, balanced accuracy, AUC, per-class
+  precision/recall/F1/support, confusion matrices) and the derived thresholds.
+- Probabilities source: `results/tabular_models/threshold/xgboost_tuned_dependent_subject_eval_dependent_baseline/probabilities_*.csv` (no model/plots in this folder — thresholds only).
+- See the threshold-objectives index: [`../README.md`](../README.md).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `objective_comparison.txt` + `objective_metrics.json` · summary auto-generated*

--- a/results/tabular_models/threshold_objectives/xgboost_tuned_independent_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/threshold_objectives/xgboost_tuned_independent_subject_eval_independent_baseline/README.md
@@ -1,0 +1,70 @@
+# xgboost_tuned_independent_subject_eval_independent_baseline — XGBoost (tuned) · subject-independent · threshold objectives
+
+> Re-derive the decision threshold under four objectives from saved validation probabilities — same tuned model, no retraining.
+
+## Overview
+- **Model:** XGBoost with the independent-tuned hyperparameters (200-trial random search; heavily
+  regularized/shallow recipe), evaluated **leak-free** (train/val/test split **by mouse**,
+  `--independent`), so no mouse appears in two sets — the honest "generalize to unseen mice" setting.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Test = 2,139 recordings (WT 1,560 / HT 579 ≈ 27.1% HT); validation WT 1,788 / HT 530.
+- **What was adapted vs the base model:** **decision-threshold objective selection only** — identical
+  fitted model, the cut is re-derived from saved validation probabilities under four objectives
+  (`youden`, `f1`, `target_recall`, `balanced`) plus the 0.5 default. Val AUC 0.641, test AUC 0.753.
+- **Recommended objective:** for **independent** splits, `target_recall` (HT-recall floor 0.80). Note the
+  weak validation signal (AUC 0.641) pushed its chosen threshold to 0.523 — *above* the 0.5 default — so
+  on test it actually **lowers** HT recall to 0.731 rather than hitting the 0.80 floor.
+
+## Results (test set)
+| Objective | thr | acc | bal-acc | HT rec | HT prec | HT F1 | WT rec |
+|---|---|---|---|---|---|---|---|
+| @0.5 (default) | 0.500 | 0.695 | 0.725 | 0.791 | 0.463 | 0.584 | 0.660 |
+| youden | 0.288 | 0.704 | 0.797 | **1.000** | 0.477 | 0.646 | 0.594 |
+| f1 | 0.288 | 0.704 | 0.797 | **1.000** | 0.477 | 0.646 | 0.594 |
+| target_recall *(rec.)* | 0.523 | 0.694 | 0.706 | 0.731 | 0.459 | 0.564 | 0.681 |
+| balanced | 0.223 | 0.704 | 0.797 | **1.000** | 0.477 | 0.646 | 0.594 |
+
+youden / f1 / balanced all collapse to the same operating point (**HT recall 1.000, WT recall 0.594** —
+every HT caught at the cost of 634 false positives): `[[WT→WT 926, WT→HT 634], [HT→WT 0, HT→HT 579]]`.
+target_recall confusion matrix: `[[1062, 498], [156, 423]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+Recommended objective (`target_recall`, thr 0.523) vs base (at the 0.5 cut):
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.694 | 0.733 | −0.039 |
+| Weighted F1 | 0.710 | 0.749 | −0.039 |
+| WT F1 | 0.765 | 0.785 | −0.020 |
+| HT F1 | 0.564 | 0.649 | −0.085 |
+| HT recall | 0.731 | 0.940 | −0.209 |
+| HT precision | 0.459 | 0.496 | −0.037 |
+
+Weighted F1 = 0.765·(1560/2139) + 0.564·(579/2139) = **0.710**.
+
+## Key insights
+- Re-thresholding cannot fix a **weak ranker**: test AUC 0.753 means the score barely separates the
+  classes, so every objective trades the same recall-for-precision along one flat curve. The three
+  recall-maximizing objectives (youden/f1/balanced) degenerate to **HT recall 1.000 / WT recall 0.594** —
+  catching all HT only by flagging 634 of 1,560 WT pups.
+- The recommended `target_recall` objective **misses its own 0.80 floor on test** (lands at 0.731): the
+  low-AUC validation signal placed the threshold at 0.523, slightly conservative, so it under-delivers
+  recall rather than over-delivering it. The floor is honored on validation, not on held-out mice.
+- Against the dependent base, this leak-free run loses across the board — HT recall −0.209, HT F1 −0.085,
+  accuracy −0.039 — the expected dependent→independent penalty plus a still-poor minority class
+  (HT precision ≈ 0.46, about half of HT calls are false positives at every objective).
+- No objective beats the 0.5 default on overall F1; the only real choice is recall-vs-precision posture,
+  not an accuracy gain.
+
+## Recommendations
+- For a maximum-recall screen, use the youden/f1/balanced cut (thr 0.288, HT recall 1.000) but treat WT
+  recall 0.594 and HT precision 0.477 as the cost — positive calls need confirmation.
+- Do not rely on `target_recall` to guarantee the 0.80 floor here; the AUC-0.641 validation signal is too
+  weak to transfer. A stronger ranker (better features/model) is the real lever — see the sibling threshold
+  and objective runs in [`../README.md`](../README.md).
+
+## Artifacts
+- `objective_comparison.txt` — per-objective thresholds, test metrics, and confusion matrices (human-readable).
+- `objective_metrics.json` — same data as JSON (thresholds, per-class precision/recall/F1, support, AUC).
+- Source probabilities: `results/tabular_models/threshold/xgboost_tuned_independent_subject_eval_independent_baseline/probabilities_*.csv` (no retraining).
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `objective_comparison.txt` + `objective_metrics.json` · summary auto-generated*

--- a/results/tabular_models/xgboost_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/xgboost_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,56 @@
+# xgboost_subject_eval_dependent_baseline — XGBoost · subject-dependent
+
+> Untuned XGBoost on the official baseline data, evaluated subject-**dependent** (random row-level split). **This is the reference base model.**
+
+## Overview
+- **Model:** XGBoost, untuned legacy recipe (`scale_pos_weight=3.12` from n_WT/n_HT; no hyperparameter
+  search). HT is the positive minority class.
+- **Evaluation split:** subject-dependent — train/val/test split **randomly at the row level**, so the
+  same mouse can appear in train and test (logged overlap: 105 mice shared train↔test). This leaks
+  per-mouse signal and gives an **optimistic** read; the leak-free `--independent` runs typically land
+  10–15 pts lower.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Train 7,393 / Val 2,465 / Test 2,465 recordings; test class balance WT 73.8% / HT 26.2%.
+- **Role:** this run **is** the anchor every other tabular run is measured against (Δ vs base).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.968 | 0.496 | — |
+| Recall | 0.660 | 0.940 | — |
+| F1 | 0.785 | 0.649 | weighted **0.749** |
+| Accuracy | | | **0.733** (train 0.771) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1199, WT→HT 619], [HT→WT 39, HT→HT 608]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+This folder **is** the base model, so there is no delta to report. Every other tabular run's
+"Δ vs base model" table is measured against the numbers above (Test accuracy 0.733, Weighted F1 0.749,
+WT F1 0.785, HT F1 0.649, HT recall 0.940, HT precision 0.496).
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The operating point is **heavily tilted toward catching HT**: HT recall 0.940 (misses only 39 of 647
+  ASD-model pups) at the cost of WT recall 0.660 — 619 WT recordings are flagged as HT.
+- **Class separation is weak** — HT precision is only 0.496, so roughly half of HT predictions are false
+  positives; HT F1 lands at 0.649 despite the strong recall.
+- Train 0.771 vs test 0.733 (0.038 gap) looks well-fit, but that small gap is **inflated by leakage** —
+  the random split lets the same mouse appear on both sides, so this is an optimistic ceiling, not an
+  unseen-mouse estimate.
+
+## Recommendations
+- Treat these numbers as an **optimistic upper bound**, not a generalization estimate; use the
+  `--independent` runs for any "new-mouse" claim.
+- HT precision ~0.50 at the default 0.5 cut means positive calls need confirmation — see the threshold
+  runs (`../threshold/`, `../threshold_objectives/`) to pick a calibrated operating point.
+
+## Artifacts
+- `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`, `plots/confusionmatrix_strain2.png`,
+  `plots/conf_matrix.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training/validation learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/xgboost_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/xgboost_subject_eval_independent_baseline/README.md
@@ -1,0 +1,63 @@
+# xgboost_subject_eval_independent_baseline — XGBoost · subject-independent
+
+> Untuned legacy XGBoost on the official baseline data, evaluated **leak-free** (split grouped by mouse).
+
+## Overview
+- **Model:** XGBoost (untuned legacy recipe; `scale_pos_weight=3.07` to weight the HT minority).
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (`--independent`), so no
+  mouse appears in two sets. This is the honest "generalize to unseen mice" setting (harder than the
+  dependent base model, which splits rows randomly and lets mice leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Train 7,866 / Val 2,318 / Test 2,139 recordings across 63 / 21 / 22 mice respectively.
+  Test = 2,139 recordings from 22 held-out mice (WT 72.9% / HT 27.1%).
+- **What was adapted vs the base model:** only the evaluation moves from subject-dependent to
+  subject-independent; the model family (XGBoost) is unchanged, isolating the cost of the leak-free split.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.841 | 0.452 | — |
+| Recall | 0.713 | 0.637 | — |
+| F1 | 0.772 | 0.529 | weighted **0.706** |
+| Accuracy | | | **0.693** (train 0.806) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 1113, WT→HT 447], [HT→WT 210, HT→HT 369]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.693 | 0.733 | −0.040 |
+| Weighted F1 | 0.706 | 0.749 | −0.043 |
+| WT F1 | 0.772 | 0.785 | −0.013 |
+| HT F1 | 0.529 | 0.649 | −0.120 |
+| HT recall | 0.637 | 0.940 | −0.303 |
+| HT precision | 0.452 | 0.496 | −0.044 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The leak-free split exacts the expected toll: every headline metric drops, with overall accuracy
+  −0.040 (0.693) and weighted F1 −0.043 (0.706) vs the optimistic dependent base.
+- The minority class collapses hardest — **HT recall falls to 0.637** (−0.303) and **HT F1 to 0.529**
+  (−0.120). The dependent base caught 94% of ASD-model pups; on unseen mice this run misses ~1 in 3.
+- Class separation stays weak: **HT precision 0.452** (−0.044) means more than half of HT predictions
+  are false positives. The model no longer over-predicts HT (447 WT→HT) the way the recall-heavy base did.
+- Train 0.806 vs test 0.693 (0.11 gap) reflects honest generalization to new mice, not the inflated
+  dependent-split fit — but the untuned recipe still leaves the HT class largely unresolved.
+
+## Recommendations
+- Use this independent run, not the dependent base, for any "new-mouse" performance estimate.
+- HT recall is poor at the default 0.5 cut — see the threshold runs (`../threshold/`,
+  `../threshold_objectives/`) to recover a controlled operating point; and compare against
+  `xgboost_tuned_independent_subject_eval_independent_baseline`, whose hyperparameters were tuned
+  specifically for this leak-free split.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/feature_importances_0.png`, `plots/feature_importance_1.png` — feature importance.
+  `plots/AUC_error.png` — AUC / error learning curve.
+- `model/xgboost_model.pkl` — fitted XGBoost. `logs/out.txt` — flags, split info, class balance.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/xgboost_tuned_dependent_subject_eval_dependent_baseline/README.md
+++ b/results/tabular_models/xgboost_tuned_dependent_subject_eval_dependent_baseline/README.md
@@ -1,0 +1,66 @@
+# xgboost_tuned_dependent_subject_eval_dependent_baseline — XGBoost (tuned-dependent) · subject-dependent
+
+> Tuned XGBoost on the official baseline data, evaluated **subject-dependent** (random row-level split, same split type the tuning targeted).
+
+## Overview
+- **Model:** XGBoost with hyperparameters from a 200-trial random search tuned for the
+  subject-dependent split (`--model xgboost_tuned_dependent`), vs the untuned legacy recipe in the
+  base model. `scale_pos_weight=3.123` keeps the minority HT class weighted.
+- **Evaluation split:** subject-dependent — random row-level split (`random (row-level)`), so the
+  same mouse appears across train/val/test (logged overlap: 106 train/val, 105 train/test, 105
+  val/test shared mice). This is the optimistic, leaky setting — the same as the base model.
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Train 7,393 / Val 2,465 / Test 2,465 rows. Test = WT 73.8% / HT 26.2%.
+- **What was adapted vs the base model:** one lever — same dependent split, but the tree
+  hyperparameters are the tuned-dependent set instead of the legacy untuned recipe.
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.931 | 0.543 | — |
+| Recall | 0.747 | 0.844 | — |
+| F1 | 0.829 | 0.661 | weighted **0.785** |
+| Accuracy | | | **0.772** (train 0.875) |
+
+Test support: WT 1,818 / HT 647 (2,465 rows). The full overall confusion matrix is not printed in
+`logs/out.txt`; the only matrix block is the "Old pup" subset `[[1358 460], [101 546]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.772 | 0.733 | +0.039 |
+| Weighted F1 | 0.785 | 0.749 | +0.036 |
+| WT F1 | 0.829 | 0.785 | +0.044 |
+| HT F1 | 0.661 | 0.649 | +0.012 |
+| HT recall | 0.844 | 0.940 | −0.096 |
+| HT precision | 0.543 | 0.496 | +0.047 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- Tuning helps overall on its native split: accuracy 0.772 (+0.039) and weighted F1 0.785 (+0.036)
+  both beat the untuned dependent base, driven mostly by WT (recall 0.747, F1 0.829 / +0.044).
+- The minority-class operating point shifts: **HT recall drops to 0.844** (−0.096), but **HT
+  precision rises to 0.543** (+0.047) — fewer false positives at the cost of missing more
+  ASD-model pups. Net HT F1 is a small gain (0.661, +0.012).
+- HT separation is still weak — precision ~0.54 means roughly half of HT calls are false positives.
+- Train 0.875 vs test 0.772 (0.10 gap) is modest, but remember the dependent split lets the same
+  mice leak across train/test, so this remains an optimistic estimate, not new-mouse performance.
+
+## Recommendations
+- For an honest "generalize to unseen mice" estimate, use the subject-independent runs, not this
+  dependent split.
+- HT recall fell at the default 0.5 cut — see the threshold runs (`../threshold/`,
+  `../threshold_objectives/`) to set a deliberate operating point if recall matters more than
+  precision.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training/validation learning curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_tuned_dependent_model.pkl` — fitted model. `logs/out.txt` — flags, split info,
+  class balance, classification report.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*

--- a/results/tabular_models/xgboost_tuned_independent_subject_eval_independent_baseline/README.md
+++ b/results/tabular_models/xgboost_tuned_independent_subject_eval_independent_baseline/README.md
@@ -1,0 +1,69 @@
+# xgboost_tuned_independent_subject_eval_independent_baseline — XGBoost (tuned, independent recipe) · subject-independent
+
+> Tuned XGBoost on the official baseline data, evaluated **leak-free** (split grouped by mouse), with hyperparameters from a 200-trial search tuned for this independent split.
+
+## Overview
+- **Model:** XGBoost with the `xgboost_tuned_independent` recipe — hyperparameters from a 200-trial
+  random search tuned specifically for the independent split (heavily regularized/shallow), with
+  `scale_pos_weight=3.07` to weight the HT minority.
+- **Evaluation split:** subject-independent — train/val/test split **by mouse** (group-aware on
+  `mouse_idx`, `--independent`), so no mouse appears in two sets. This is the honest "generalize to
+  unseen mice" setting (harder than the dependent base model, which splits rows randomly and lets mice
+  leak across train/test).
+- **Dataset:** official baseline (Issue #46 filters; April-2026 HET→WT correction).
+  Train 7,866 rows / 63 mice, Val 2,318 rows / 21 mice, Test 2,139 rows from 22 held-out mice
+  (WT 72.9% / HT 27.1%).
+- **What was adapted vs the base model:** two levers change together — tuned hyperparameters (vs the
+  untuned legacy base recipe) **and** evaluation moves from subject-dependent to subject-independent.
+  Tuning and evaluation split are matched here (independent recipe on the independent split).
+
+## Results (test set)
+| Metric | WT | HT | Overall |
+|---|---|---|---|
+| Precision | 0.929 | 0.473 | — |
+| Recall | 0.640 | 0.869 | — |
+| F1 | 0.758 | 0.612 | weighted **0.719** |
+| Accuracy | | | **0.702** (train 0.714) |
+
+Confusion matrix (rows = true, cols = pred): `[[WT→WT 999, WT→HT 561], [HT→WT 76, HT→HT 503]]`.
+
+## Δ vs base model (`xgboost_subject_eval_dependent_baseline`)
+| Metric | This run | Base | Δ |
+|---|---|---|---|
+| Test accuracy | 0.702 | 0.733 | −0.031 |
+| Weighted F1 | 0.719 | 0.749 | −0.030 |
+| WT F1 | 0.758 | 0.785 | −0.027 |
+| HT F1 | 0.612 | 0.649 | −0.037 |
+| HT recall | 0.869 | 0.940 | −0.071 |
+| HT precision | 0.473 | 0.496 | −0.023 |
+
+*Ignore the `baseline:` column inside `comparison_vs_baseline.txt` — it is a legacy 0.829 reference, not our base model.*
+
+## Key insights
+- The honest leak-free split costs only modestly here: accuracy 0.702 and weighted F1 0.719 land about
+  0.03 below the dependent base model — far short of the usual 10–15 pt dependent→independent drop, so
+  the regularized tuned recipe generalizes well to unseen mice.
+- Train 0.714 vs test 0.702 (0.01 gap) shows almost no overfitting — the shallow, heavily regularized
+  recipe is doing its job; the model is not memorizing training mice.
+- The minority class stays high-recall but imprecise: **HT recall 0.869** with **HT precision 0.473**
+  means more than half of HT predictions are false positives (561 WT recordings called HT). The model
+  still leans toward flagging HT, much like the base.
+- WT recall drops to 0.640 (−0.020 vs base) — the price of the HT-leaning operating point is missing
+  ~36% of true WT recordings.
+
+## Recommendations
+- HT precision ≈ 0.47 at the default 0.5 cut, so positive calls need confirmation; tune the threshold
+  (see `../threshold/`, `../threshold_objectives/`) to trade some HT recall for cleaner precision.
+- Use this independent run, not the dependent base, for any "new-mouse" performance estimate — the
+  hyperparameters and the evaluation split are matched, so it is the honest generalization number.
+
+## Artifacts
+- `plots/conf_matrix.png`, `plots/confusionmatrix.png`, `plots/confusionmatrix_strain1.png`,
+  `plots/confusionmatrix_strain2.png` — confusion matrices (overall + per strain).
+- `plots/AUC_error.png` — training/validation AUC curve. `plots/feature_importances_0.png`,
+  `plots/feature_importance_1.png` — feature importances.
+- `model/xgboost_tuned_independent_model.pkl` — fitted model. `logs/out.txt` — flags, split info,
+  class balance, confusion matrix.
+- Metrics source: `comparison_vs_baseline.txt` (run column only) + `logs/out.txt`.
+---
+*Base model: `xgboost_subject_eval_dependent_baseline` · metrics from `comparison_vs_baseline.txt` + `logs/out.txt` · summary auto-generated*


### PR DESCRIPTION
## Summary
Adds a uniform `README.md` at the root of **every model-run folder** under `results/`, so each run is
self-documenting without opening the raw `out.txt` / `results.json` / `comparison_vs_baseline.txt`
artifacts. **101 files** (99 per-run summaries + 2 container index READMEs).

Every summary follows one template:
- **Overview** — model + what was adapted vs the base model, in research context (WT vs HT/HET ASD-model
  classification, dependent vs independent eval, baseline data, model variant / strain / threshold
  objective / NN lever).
- **Results (test set)** — the run's own numbers, read from its own artifacts.
- **Δ vs base model** — every run compared to the anchor
  `results/tabular_models/xgboost_subject_eval_dependent_baseline` (test acc **0.733** / weighted F1 **0.749**).
- **Key insights** + optional **Recommendations** + **Artifacts**.

## Scope
- Tabular top-level (6), `strain/` (12), `threshold/` (6), `threshold_objectives/` (6),
  NN baselines (6), NN experiments A–H (38), and archived `legacy/` runs (25).
- Container index READMEs for `strain/` and `experiments/` roots.

## Key decisions
- The legacy `baseline: 0.829` column inside `comparison_vs_baseline.txt` is **ignored**; a footnote in
  each file tells readers so. The only base-model anchor is the run above.
- `legacy/` summaries are marked **archived / superseded**, and any pre-existing hand-written notes are
  preserved under an `## Original notes` section.
- The curated root READMEs in `threshold/` and `threshold_objectives/` are **left untouched**.
- No source artifacts, plots, models, or training code were modified — docs only.

## How it was produced
A multi-agent author→adversarial-verify pass generated each file from its folder's own artifacts and a
shared research-context brief; a second agent re-checked every metric against the source and the
Δ-vs-base arithmetic. Final sweep: 99/99 files present, all template sections present, no run misuses the
legacy 0.829 value as the base.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)